### PR TITLE
Security: TLS and authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ crossbeam = "0.7"
 env_logger = "*"
 err-derive = "0.2"
 glib = "*"
+gio = "0.8"
 gstreamer = "0.15"
 gstreamer-app = "0.15"
 gstreamer-rtsp = "0.15"
-gstreamer-rtsp-server = "0.15"
+gstreamer-rtsp-server = { version = "0.15", features = ["v1_12"]}
 lazy_static = "1.4"
 log = { version = "0.4" }
 indoc = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ gstreamer-rtsp-server = { version = "0.15", features = ["v1_12", "v1_14"]}
 lazy_static = "1.4"
 log = { version = "0.4" }
 indoc = "0.3"
+itertools = "0.9"
 md5 = "0.7"
 nom = "5.1"
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ gio = "0.8"
 gstreamer = "0.15"
 gstreamer-app = "0.15"
 gstreamer-rtsp = "0.15"
-gstreamer-rtsp-server = { version = "0.15", features = ["v1_12"]}
+gstreamer-rtsp-server = { version = "0.15", features = ["v1_12", "v1_14"]}
 lazy_static = "1.4"
 log = { version = "0.4" }
 indoc = "0.3"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ By default the HD stream is mounted at `name` and at `name/mainStream` and the S
 By default Neolink serves on all IP addresses on port 8554.
 You can modify this by changing the `bind` and the `bind_port` parameter.
 
+Use can enable `rtsps` (TLS) by adding a `certificate = "/path/to/pem"` to the config. This pem should contain by the certificate and the key used for the server. If TLS is enabled all connections must use `rtsps`. Use can also control client side TLS with the config option `tls_client_auth = "none|request|require"`, in this case the client should present a certificate signed by the server's CA, this is disabled by default.
+
+Use can enable basic authentication by adding the configuration option `username = "someone"` and `password = "somepass"`. Both username and password must be set for this to work.
+
 You can change the Neolink log level by setting the `RUST_LOG` environment variable (not in the configuration file) to one of `error`, `warn`, `info`, `debug`, or `trace`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Anywhere a username is accepted it can take any username or one of the following
 - `anyone` means any user with a valid user/pass
 - `anonymous` means no user/pass required
 
-The default `permitted_users` list is `[ "anonymous" ]` meaning no authentication required. If you want to use authenitcation then after adding your users through `[[users]]` please ensure you update the `permittted_users` for each camera.
+The default `permitted_users` list is:
+- `[ "anonymous"]` if no `[[users]]` were given in the config meaning no authentication required to connect.
+- `[ "anyone" ]` if `[[users]]` were provided meaning any authourised users can connect.
 
 You can change the Neolink log level by setting the `RUST_LOG` environment variable (not in the configuration file) to one of `error`, `warn`, `info`, `debug`, or `trace`:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Currently Neolink cannot auto-detect cameras like the official clients do; you m
 
 By default the h265 streaming format is used. Some cameras, for example E1, provide h264 streams, to use these you must specify `format = "h264"` in the `[[cameras]]` config.
 
-By default the HD stream is used. To swap to the SD stream add `stream = "subStream"` to the `[[cameras]]` config. You may also need to use `h264` format while using the SD stream.
+By default the HD stream is mounted at `name` and at `name/mainStream` and the SD stream is mounted at `name/subStream`. You can specify mounting only one by adding `stream = "subStream"` to the `[[cameras]]` config. You may also need to use `h264` format while using the SD stream.
 
 By default Neolink serves on all IP addresses on port 8554.
 You can modify this by changing the `bind` and the `bind_port` parameter.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You may also need to use `h264` format while using the SD stream.
 By default Neolink serves on all IP addresses on port 8554.
 You can modify this by changing the `bind` and the `bind_port` parameter.
 
-Use can enable `rtsps` (TLS) by adding a `certificate = "/path/to/pem"` to the config. This pem should contain by the certificate and the key used for the server. If TLS is enabled all connections must use `rtsps`. Use can also control client side TLS with the config option `tls_client_auth = "none|request|require"`, in this case the client should present a certificate signed by the server's CA, this is disabled by default.
+Use can enable `rtsps` (TLS) by adding a `certificate = "/path/to/pem"` to the config. This pem should contain by the certificate and the key used for the server. If TLS is enabled all connections must use `rtsps`. You can also control client side TLS with the config option `tls_client_auth = "none|request|require"`, in this case the client should present a certificate signed by the server's CA, this is disabled by default.
 
 Use can enable basic authentication by adding the configuration option `username = "someone"` and `password = "somepass"`. Both username and password must be set for this to work.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ you also need to add the allowed users into each camera by adding the following 
 permitted_users = ["someone", "someoneelse"]
 ```
 
+Anywhere a username is accepted it can take any username or one of the following special values.
+- `anyone` means any user with a valid user/pass
+- `anonymous` means no user/pass required
+
 You can change the Neolink log level by setting the `RUST_LOG` environment variable (not in the configuration file) to one of `error`, `warn`, `info`, `debug`, or `trace`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Anywhere a username is accepted it can take any username or one of the following
 - `anyone` means any user with a valid user/pass
 - `anonymous` means no user/pass required
 
+The default `permitted_users` list is `[ "anonymous" ]` meaning no authentication required. If you want to use authenitcation then after adding your users through `[[users]]` please ensure you update the `permittted_users` for each camera.
+
 You can change the Neolink log level by setting the `RUST_LOG` environment variable (not in the configuration file) to one of `error`, `warn`, `info`, `debug`, or `trace`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -93,9 +93,11 @@ You may also need to use `h264` format while using the SD stream.
 By default Neolink serves on all IP addresses on port 8554.
 You can modify this by changing the `bind` and the `bind_port` parameter.
 
-Use can enable `rtsps` (TLS) by adding a `certificate = "/path/to/pem"` to the config. This pem should contain by the certificate and the key used for the server. If TLS is enabled all connections must use `rtsps`. You can also control client side TLS with the config option `tls_client_auth = "none|request|require"`, in this case the client should present a certificate signed by the server's CA, this is disabled by default.
+You can enable `rtsps` (TLS) by adding a `certificate = "/path/to/pem"` to the top section of the config file. This PEM should contain by the certificate and the key used for the server. If TLS is enabled all connections must use `rtsps`. You can also control client side TLS with the config option `tls_client_auth = "none|request|require"`; in this case the client should present a certificate signed by the server's CA.
 
-Use can enable basic authentication by adding users to the configuration file as:
+TLS is disabled by default.
+
+You can password-protect the Neolink server by adding `[[users]]`` sections to the configuration file:
 ```
 [[users]]
 name: someone

--- a/sample_config.toml
+++ b/sample_config.toml
@@ -1,13 +1,43 @@
+# A bind value of 0.0.0.0 means any network this computer can access
+# You can chage this to a specfic network e.g. "192.168.1.101" here
+# Or to no networks e.g. this computer only "127.0.0.1"
 bind = "0.0.0.0"
+# Default port is 8554 but you can change it by uncommenting the following
+# bind_port = 8554
+
+# Uncomment the following and supply a path to a valid PEM
+# to activate TLS encryption.
+# The PEM should contain the certificate and the private key
+# If TLS is activated you must connect with "rtsps://" and not "rtsp://"
+# certificate = "/path/to/pem/with/cert/and/key"
+
+# You can password protect the rtsp server mount points by adding users
+# like the following me and someone. If you do not add [[users]]
+# then anyone can connect without a password or username
+# To access such a stream try using a url such as "rtsp://me:mepass@192.168.1.101/driveway"
+[[users]]
+name = "me"
+pass = "mepass"
+
+[[users]]
+name = "someone"
+pass = "someonepass"
+
 
 [[cameras]]
 name = "driveway"
 username = "admin"
 password = "12345678"
 address = "192.168.1.187:9000"
+# By default any of the users can connect (or anyone at all if no users are specfied)
+# You can uncomment the following to permit only specfic users
+# permitted_users = [ "me" ]
 
 [[cameras]]
 name = "storage shed"
 username = "admin"
 password = "987654321"
 address = "192.168.1.245:9000"
+# By default the camera is assumed to be in H.265 format
+# Some camera's e.g. E1 use H.264. You can use the following to change this
+# format = "h264"

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,7 +105,7 @@ fn default_tls_client_auth() -> String {
 }
 
 fn default_permitted_users() -> Vec<String> {
-    vec!["anyone".to_string()]
+    vec!["anonymous".to_string()]
 }
 
 fn default_users() -> Vec<UserConfig> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,8 +30,8 @@ pub struct Config {
 
     #[validate(regex(
         path = "RE_TLS_CLIENT_AUTH",
-        message = "Incorrect stream format",
-        code = "format"
+        message = "Incorrect tls auth",
+        code = "tls_client_auth"
     ))]
     #[serde(default = "default_tls_client_auth")]
     pub tls_client_auth: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,11 @@ pub struct Config {
     #[serde(default = "default_certificate")]
     pub certificate: Option<String>,
 
-    #[validate(regex(path = "RE_TLS_CLIENT_AUTH", message = "Incorrect stream format", code = "format"))]
+    #[validate(regex(
+        path = "RE_TLS_CLIENT_AUTH",
+        message = "Incorrect stream format",
+        code = "format"
+    ))]
     #[serde(default = "default_tls_client_auth")]
     pub tls_client_auth: String,
 
@@ -112,8 +116,8 @@ fn default_users() -> Vec<UserConfig> {
     vec![]
 }
 
-fn validate_username(name: &str)  -> Result<(), ValidationError> {
-    let reserved_names = vec!("anyone", "anonymous");
+fn validate_username(name: &str) -> Result<(), ValidationError> {
+    let reserved_names = vec!["anyone", "anonymous"];
     if reserved_names.contains(&name) {
         return Err(ValidationError::new("This is a reserved username"));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub tls_client_auth: String,
 
     #[validate]
+    #[serde(default = "default_users")]
     pub users: Vec<UserConfig>,
 }
 
@@ -95,4 +96,8 @@ fn default_tls_client_auth() -> String {
 
 fn default_permitted_users() -> Vec<String> {
     vec!["anyone".to_string()]
+}
+
+fn default_users() -> Vec<UserConfig> {
+    vec![]
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 lazy_static! {
     static ref RE_STREAM_FORM: Regex = Regex::new(r"^([hH]26[45]|[ \t]*[!].*)$").unwrap();
     static ref RE_STREAM_SRC: Regex = Regex::new(r"^(mainStream|subStream|both)$").unwrap();
+    static ref RE_TLS_CLIENT_AUTH: Regex = Regex::new(r"^(none|request|require)$").unwrap();
 }
 
 #[derive(Debug, Deserialize, Validate, Clone)]
@@ -21,6 +22,13 @@ pub struct Config {
     #[validate(range(min = 0, max = 65535, message = "Invalid port", code = "bind_port"))]
     #[serde(default = "default_bind_port")]
     pub bind_port: u16,
+
+    #[serde(default = "default_certificate")]
+    pub certificate: String,
+
+    #[validate(regex(path = "RE_TLS_CLIENT_AUTH", message = "Incorrect stream format", code = "format"))]
+    #[serde(default = "default_tls_client_auth")]
+    pub tls_client_auth: String,
 }
 
 #[derive(Debug, Deserialize, Validate, Clone)]
@@ -58,4 +66,12 @@ fn default_format() -> String {
 
 fn default_stream() -> String {
     "both".to_string()
+}
+
+fn default_certificate() -> String {
+    "".to_string()
+}
+
+fn default_tls_client_auth() -> String {
+    "none".to_string()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,16 @@
 use serde::Deserialize;
 use std::net::SocketAddr;
 use std::time::Duration;
+use std::clone::Clone;
 use validator::Validate;
 use regex::Regex;
 
 lazy_static! {
     static ref RE_STREAM_FORM: Regex = Regex::new(r"^([hH]26[45]|[ \t]*[!].*)$").unwrap();
-    static ref RE_STREAM_SRC: Regex = Regex::new(r"^(mainStream|subStream)$").unwrap();
+    static ref RE_STREAM_SRC: Regex = Regex::new(r"^(mainStream|subStream|both)$").unwrap();
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, Clone)]
 pub struct Config {
     pub cameras: Vec<CameraConfig>,
 
@@ -21,7 +22,7 @@ pub struct Config {
     pub bind_port: u16,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, Clone)]
 pub struct CameraConfig {
     pub name: String,
 
@@ -55,5 +56,5 @@ fn default_format() -> String {
 }
 
 fn default_stream() -> String {
-    "mainStream".to_string()
+    "both".to_string()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ lazy_static! {
 
 #[derive(Debug, Deserialize, Validate, Clone)]
 pub struct Config {
+    #[validate]
     pub cameras: Vec<CameraConfig>,
 
     #[serde(rename = "bind", default = "default_bind_addr")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,12 @@ pub struct Config {
     #[serde(default = "default_certificate")]
     pub certificate: String,
 
+    #[serde(default = "default_username")]
+    pub username: String,
+
+    #[serde(default = "default_password")]
+    pub password: String,
+
     #[validate(regex(path = "RE_TLS_CLIENT_AUTH", message = "Incorrect stream format", code = "format"))]
     #[serde(default = "default_tls_client_auth")]
     pub tls_client_auth: String,
@@ -74,4 +80,12 @@ fn default_certificate() -> String {
 
 fn default_tls_client_auth() -> String {
     "none".to_string()
+}
+
+fn default_username() -> String {
+    "".to_string()
+}
+
+fn default_password() -> String {
+    "".to_string()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
     pub bind_port: u16,
 
     #[serde(default = "default_certificate")]
-    pub certificate: String,
+    pub certificate: Option<String>,
 
     #[serde(default = "default_username")]
     pub username: Option<String>,
@@ -74,8 +74,8 @@ fn default_stream() -> String {
     "both".to_string()
 }
 
-fn default_certificate() -> String {
-    "".to_string()
+fn default_certificate() -> Option<String> {
+    None
 }
 
 fn default_tls_client_auth() -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,10 +27,10 @@ pub struct Config {
     pub certificate: String,
 
     #[serde(default = "default_username")]
-    pub username: String,
+    pub username: Option<String>,
 
     #[serde(default = "default_password")]
-    pub password: String,
+    pub password: Option<String>,
 
     #[validate(regex(path = "RE_TLS_CLIENT_AUTH", message = "Incorrect stream format", code = "format"))]
     #[serde(default = "default_tls_client_auth")]
@@ -82,10 +82,10 @@ fn default_tls_client_auth() -> String {
     "none".to_string()
 }
 
-fn default_username() -> String {
-    "".to_string()
+fn default_username() -> Option<String> {
+    None
 }
 
-fn default_password() -> String {
-    "".to_string()
+fn default_password() -> Option<String> {
+    None
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,7 @@ pub struct CameraConfig {
     pub stream: String,
 
     #[serde(default = "default_permitted_users")]
-    pub permitted_users: Vec<String>,
+    pub permitted_users: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Validate, Clone)]
@@ -108,8 +108,8 @@ fn default_tls_client_auth() -> String {
     "none".to_string()
 }
 
-fn default_permitted_users() -> Vec<String> {
-    vec!["anonymous".to_string()]
+fn default_permitted_users() -> Option<Vec<String>> {
+    None
 }
 
 fn default_users() -> Vec<UserConfig> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use std::clone::Clone;
 use std::net::SocketAddr;
 use std::time::Duration;
-use validator::Validate;
+use validator::{Validate, ValidationError};
 use validator_derive::Validate;
 
 lazy_static! {
@@ -71,7 +71,7 @@ pub struct CameraConfig {
 
 #[derive(Debug, Deserialize, Validate, Clone)]
 pub struct UserConfig {
-    #[validate(required)]
+    #[validate(required, custom = "validate_username")]
     #[serde(alias = "username")]
     pub name: Option<String>,
 
@@ -110,4 +110,12 @@ fn default_permitted_users() -> Vec<String> {
 
 fn default_users() -> Vec<UserConfig> {
     vec![]
+}
+
+fn validate_username(name: &str)  -> Result<(), ValidationError> {
+    let reserved_names = vec!("anyone", "anonymous");
+    if reserved_names.contains(&name) {
+        return Err(ValidationError::new("This is a reserved username"));
+    }
+    Ok(())
 }

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -50,7 +50,7 @@ impl RtspServer {
         let factory = RTSPMediaFactory::new();
 
         for permitted_user in permitted_users {
-            debug!("Permitting {} to access {}", permitted_user, names.join(", "));
+            debug!("Permitting {} to access {}", permitted_user, paths.join(", "));
             self.add_watcher_role(&factory, &permitted_user)
         }
         // During auth, first it binds anonymously. At this point it checks
@@ -60,7 +60,7 @@ impl RtspServer {
         // It loads the auth token of the user and checks that users
         // RTSP_PERM_MEDIA_FACTORY_CONSTRUCT allowing them to play
         // As a result of this we must ensure that if anonymous is not granted watcher
-        // access that anon has at least RTSP_PERM_MEDIA_FACTORY_ACCESS 
+        // access that anon has at least RTSP_PERM_MEDIA_FACTORY_ACCESS
         if ! permitted_users.contains(&"anonymous".to_string()) {
             self.add_check_role(&factory, "anonymous");
         }

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -100,23 +100,20 @@ impl RtspServer {
     pub fn set_credentials(&self, user_pass: Option<(&str, &str)>) -> Result<()> {
         let auth = self.server.get_auth().unwrap_or_else(|| RTSPAuth::new());
 
-        match user_pass {
-            Some((user, pass)) => {
-                    debug!("Setting credentials for user {}", user);
-                    debug!("Password is {}", pass);
-                    let token = RTSPToken::new(&[(*RTSP_TOKEN_MEDIA_FACTORY_ROLE, &"watcher")]);
-                    let basic = RTSPAuth::make_basic(user, pass);
-                    auth.set_supported_methods(RTSPAuthMethod::Basic);
-                    auth.add_basic(basic.as_str(), &token);
+        if let Some((user, pass)) = user_pass {
+            debug!("Setting credentials for user {}", user);
+            debug!("Password is {}", pass);
+            let token = RTSPToken::new(&[(*RTSP_TOKEN_MEDIA_FACTORY_ROLE, &"watcher")]);
+            let basic = RTSPAuth::make_basic(user, pass);
+            auth.set_supported_methods(RTSPAuthMethod::Basic);
+            auth.add_basic(basic.as_str(), &token);
 
-                    // Now we have basic auth we stop others from watching
-                    let mut token = RTSPToken::new_empty();
-                    auth.set_default_token(Some(&mut token));
-            },
-            None => {
-                let mut token = RTSPToken::new(&[(*RTSP_TOKEN_MEDIA_FACTORY_ROLE, &"watcher")]);
-                auth.set_default_token(Some(&mut token)); //By default anyone can watch if we don't turn on basic
-            }
+            // Now we have basic auth we stop others from watching
+            let mut token = RTSPToken::new_empty();
+            auth.set_default_token(Some(&mut token));
+        } else {
+            let mut token = RTSPToken::new(&[(*RTSP_TOKEN_MEDIA_FACTORY_ROLE, &"watcher")]);
+            auth.set_default_token(Some(&mut token)); //By default anyone can watch if we don't turn on basic
         }
 
         self.server.set_auth(Some(&auth));

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -124,17 +124,15 @@ impl RtspServer {
     }
 
     pub fn set_tls(&self, cert_file: &str, client_auth: TlsAuthenticationMode) -> Result<()> {
-        if ! cert_file.is_empty() {
-            debug!("Setting up TLS using {}", cert_file);
-            let auth = self.server.get_auth().unwrap_or_else(|| RTSPAuth::new());
+        debug!("Setting up TLS using {}", cert_file);
+        let auth = self.server.get_auth().unwrap_or_else(|| RTSPAuth::new());
 
-            let cert = TlsCertificate::new_from_file(cert_file).expect("Not a valid TLS certificate or not found.");
-            auth.set_tls_certificate(Some(&cert));
-            auth.set_tls_authentication_mode(client_auth);
-            auth.set_supported_methods(RTSPAuthMethod::None);
+        let cert = TlsCertificate::new_from_file(&cert_file).expect("Not a valid TLS certificate or not found.");
+        auth.set_tls_certificate(Some(&cert));
+        auth.set_tls_authentication_mode(client_auth);
+        auth.set_supported_methods(RTSPAuthMethod::None);
 
-            self.server.set_auth(Some(&auth));
-        }
+        self.server.set_auth(Some(&auth));
         Ok(())
     }
 

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -15,9 +15,11 @@ use gstreamer_rtsp_server::{
     RTSP_TOKEN_MEDIA_FACTORY_ROLE,
 };
 use log::debug;
+use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::io::Write;
+use itertools::Itertools;
 
 type Result<T> = std::result::Result<T, ()>;
 
@@ -43,7 +45,7 @@ impl RtspServer {
         &self,
         paths: &[&str],
         stream_format: &StreamFormat,
-        permitted_users: &[String],
+        permitted_users: &HashSet<String>,
     ) -> Result<MaybeAppSrc> {
         let mounts = self
             .server
@@ -60,7 +62,8 @@ impl RtspServer {
 
         debug!(
             "Permitting {} to access {}",
-            permitted_users.join(", "),
+            // This is hashmap or (iter) equivalent of join, it requres itertools
+            permitted_users.iter().cloned().intersperse(", ".to_string()).collect::<String>(),
             paths.join(", ")
         );
         self.add_permitted_roles(&factory, permitted_users);
@@ -104,7 +107,7 @@ impl RtspServer {
         Ok(maybe_app_src)
     }
 
-    pub fn add_permitted_roles(&self, factory: &RTSPMediaFactory, permitted_roles: &[String]) {
+    pub fn add_permitted_roles(&self, factory: &RTSPMediaFactory, permitted_roles: &HashSet<String>) {
         for permitted_role in permitted_roles {
             factory.add_role_from_structure(&Structure::new(
                 permitted_role.as_str(),

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -12,6 +12,7 @@ use gstreamer_rtsp_server::{RTSPAuth, RTSPToken, RTSPMediaFactory, RTSP_TOKEN_ME
 use log::debug;
 use std::io;
 use std::io::Write;
+use std::fs;
 use gio::{TlsCertificate,TlsAuthenticationMode};
 
 type Result<T> = std::result::Result<T, ()>;
@@ -124,7 +125,9 @@ impl RtspServer {
         debug!("Setting up TLS using {}", cert_file);
         let auth = self.server.get_auth().unwrap_or_else(|| RTSPAuth::new());
 
-        let cert = TlsCertificate::new_from_file(&cert_file).expect("Not a valid TLS certificate or not found.");
+        // We seperate reading the file and changing to a PEM so that we get different error messages.
+        let cert_contents = fs::read_to_string(cert_file).expect("TLS file not found");
+        let cert = TlsCertificate::new_from_pem(&cert_contents).expect("Not a valid TLS certificate");
         auth.set_tls_certificate(Some(&cert));
         auth.set_tls_authentication_mode(client_auth);
         auth.set_supported_methods(RTSPAuthMethod::None);

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -9,7 +9,7 @@ use gstreamer_app::AppSrc;
 use gstreamer_rtsp_server::prelude::*;
 use gstreamer_rtsp::RTSPAuthMethod;
 use gstreamer_rtsp_server::{RTSPAuth, RTSPToken, RTSPMediaFactory, RTSP_TOKEN_MEDIA_FACTORY_ROLE, RTSP_PERM_MEDIA_FACTORY_ACCESS, RTSP_PERM_MEDIA_FACTORY_CONSTRUCT, RTSPServer as GstRTSPServer};
-use log::{debug, info};
+use log::debug;
 use std::io;
 use std::io::Write;
 use std::fs;
@@ -123,7 +123,7 @@ impl RtspServer {
 
     pub fn set_tls(&self, cert_file: &str, client_auth: TlsAuthenticationMode) -> Result<()> {
         if ! cert_file.is_empty() {
-            info!("Setting up TLS using {}", cert_file);
+            debug!("Setting up TLS using {}", cert_file);
             let auth = self.server.get_auth().unwrap_or_else(RTSPAuth::new());
 
             let cert = TlsCertificate::new_from_pem(&fs::read_to_string(cert_file).expect("TLS file not found")).expect("Not a valid TLS certificate");

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -149,7 +149,6 @@ impl RtspServer {
         for credential in credentials {
             if let Some((user, pass)) = credential {
                 debug!("Setting credentials for user {}", user);
-                debug!("Password is {}", pass);
                 let token = RTSPToken::new(&[(*RTSP_TOKEN_MEDIA_FACTORY_ROLE, user)]);
                 let basic = RTSPAuth::make_basic(user, pass);
                 auth.add_basic(basic.as_str(), &token);

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -99,10 +99,7 @@ impl RtspServer {
     }
 
     pub fn set_credentials(&self, user :&str, pass :&str) -> Result<()> {
-        let auth = match self.server.get_auth() {
-            Some(x) => x,
-            None =>  RTSPAuth::new(),
-        };
+        let auth = self.server.get_auth().unwrap_or_else(RTSPAuth::new());
 
         if ! user.is_empty() && ! pass.is_empty() {
             debug!("Setting credentials for user {}", user);
@@ -127,10 +124,7 @@ impl RtspServer {
     pub fn set_tls(&self, cert_file: &str, client_auth: TlsAuthenticationMode) -> Result<()> {
         if ! cert_file.is_empty() {
             info!("Setting up TLS using {}", cert_file);
-            let auth = match self.server.get_auth() {
-                Some(x) => x,
-                None =>  RTSPAuth::new(),
-            };
+            let auth = self.server.get_auth().unwrap_or_else(RTSPAuth::new());
 
             let cert = TlsCertificate::new_from_pem(&fs::read_to_string(cert_file).expect("TLS file not found")).expect("Not a valid TLS certificate");
             auth.set_tls_certificate(Some(&cert));

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -35,7 +35,7 @@ impl RtspServer {
         }
     }
 
-    pub fn add_stream(&self, paths: &[&str], stream_format: &StreamFormat, permitted_users: &Vec<String>) -> Result<MaybeAppSrc> {
+    pub fn add_stream(&self, paths: &[&str], stream_format: &StreamFormat, permitted_users: &[String]) -> Result<MaybeAppSrc> {
         let mounts = self
             .server
             .get_mount_points()
@@ -91,7 +91,7 @@ impl RtspServer {
         Ok(maybe_app_src)
     }
 
-    pub fn add_permitted_roles(&self, factory: &RTSPMediaFactory, permitted_roles: &Vec<String>) {
+    pub fn add_permitted_roles(&self, factory: &RTSPMediaFactory, permitted_roles: &[String]) {
         for permitted_role in permitted_roles {
             factory.add_role_from_structure(
                 &Structure::new(

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -126,7 +126,7 @@ impl RtspServer {
             debug!("Setting up TLS using {}", cert_file);
             let auth = self.server.get_auth().unwrap_or_else(RTSPAuth::new());
 
-            let cert = TlsCertificate::new_from_pem(&fs::read_to_string(cert_file).expect("TLS file not found")).expect("Not a valid TLS certificate");
+            let cert = TlsCertificate::new_from_file(cert_file).expect("Not a valid TLS certificate or not found.");
             auth.set_tls_certificate(Some(&cert));
             auth.set_tls_authentication_mode(client_auth);
             auth.set_supported_methods(RTSPAuthMethod::None);

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -105,7 +105,7 @@ impl RtspServer {
         };
 
         if ! user.is_empty() && ! pass.is_empty() {
-            info!("Setting credentials for user {}", user);
+            debug!("Setting credentials for user {}", user);
             debug!("Password is {}", pass);
             let token = RTSPToken::new(&[(*RTSP_TOKEN_MEDIA_FACTORY_ROLE, &"watcher")]);
             let basic = RTSPAuth::make_basic(user, pass);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
+use std::collections::HashSet;
 use structopt::StructOpt;
 use validator::Validate;
 use gio::TlsAuthenticationMode;
@@ -182,22 +183,23 @@ fn get_permitted_users(users: &Vec<UserConfig>, current_permitted_users: &Vec<St
     // ===Special set up of "anyone"===
     // If in the camera config there is the user "anyone"
     // Then we add all users to the cameras config. including unauth
-    let mut new_permitted_users = vec![];
+    let mut new_permitted_users = HashSet::new();
     if current_permitted_users.contains(&"anyone".to_string()) {
         for credentials in users {
             if let Some(user) = &credentials.name {
-                new_permitted_users.push(user.to_string());
+                new_permitted_users.insert(user.to_string());
             }
         }
-        new_permitted_users.push("anonymous".to_string());
     } else {
-        new_permitted_users.append(&mut current_permitted_users.clone());
+        for user in current_permitted_users {
+            new_permitted_users.insert(user.to_string());
+        }
     }
-    // We also drop duplicated user names
-    new_permitted_users.sort();
-    new_permitted_users.dedup();
-
-    new_permitted_users
+    let mut result = vec![];
+    for user in new_permitted_users {
+        result.push(user);
+    }
+    result
 }
 
 fn camera_main(

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,14 +153,7 @@ fn set_up_tls(config: &Config, rtsp: &RtspServer) {
 fn set_up_users(users: &Vec<UserConfig>, rtsp: &RtspServer) {
     // Setting up users
     let mut credentials = vec![];
-    let reserved_names = vec!(String::from("anyone"), String::from("anonymous"));
     for user in users {
-        if let Some(name) = &user.name {
-            if reserved_names.contains(name) {
-                warn!("{} is a reserved username, skipping this user", name);
-                continue;
-            }
-        }
         let name = &user.name;
         let pass = &user.pass;
         let user_pass = match (name, pass)  {

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,8 +177,22 @@ fn set_up_users(users: &Vec<UserConfig>, rtsp: &RtspServer) {
 
 fn get_permitted_users(
     users: &Vec<UserConfig>,
-    current_permitted_users: &Vec<String>,
+    permitted_users: &Option<Vec<String>>,
 ) -> Vec<String> {
+    let current_permitted_users = match permitted_users {
+        Some(permitted_users) => permitted_users.clone().to_owned(),
+        None => {
+            // If None then the users didn't specify permitted_users
+            // In this case we do either
+            // - Any authourised user if [[users]] was specified
+            // - Any connecting user if [[users]] was not added
+            if users.len() > 0 {
+                vec!("anyone".to_string())
+            } else {
+                vec!("anonymous".to_string())
+            }
+        }
+    };
     // This is required to handle the special case of "anyone"
     // ===Special set up of "anyone"===
     // If in the camera config there is the user "anyone"

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,13 @@ fn main() -> Result<(), Error> {
     };
     rtsp.set_tls(&config.certificate, tls_client_auth).expect("Failed to set up TLS");
 
-    rtsp.set_credentials(&config.username, &config.password).expect("Failed to set up users.");
+    let name = &config.username;
+    let pass = &config.password;
+    let user_pass = match (name, pass)  {
+        (Some(name), Some(pass)) => Some((&name as &str, &pass as &str)),
+        _ => None,
+    };
+    rtsp.set_credentials(user_pass).expect("Failed to set up users.");
 
 
     crossbeam::scope(|s| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,20 +148,29 @@ fn set_up_tls(config: &Config, rtsp: &RtspServer) {
 fn set_up_users(users: &Vec<UserConfig>, rtsp: &RtspServer) {
     // Setting up users
     let mut credentials = vec![];
+    let reserved_names = vec!(String::from("anyone"), String::from("anonymous"));
     for user in users {
+        if let Some(name) = &user.name {
+            if reserved_names.contains(name) {
+                warn!("{} is a reserved username, skipping this user", name);
+                continue;
+            }
+        }
         let name = &user.name;
         let pass = &user.pass;
         let user_pass = match (name, pass)  {
-            (Some(name), Some(pass)) => Some((&name as &str, &pass as &str)),
+            (Some(name), Some(pass)) => {
+                Some((&name as &str, &pass as &str))
+            }
             (Some(name), None) => {
                 warn!("One of the users has no password, skipping this user");
                 debug!("The skipped user was {}", name);
                 None
-            }
+            },
             (None, Some(_pass)) => {
                 warn!("One of the users has a password but no name, skipping this user");
                 None
-            }
+            },
             _ => None,
         };
         credentials.push(user_pass);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 use std::time::Duration;
 use structopt::StructOpt;
 use validator::Validate;
+use gio::TlsAuthenticationMode;
 
 mod cmdline;
 mod config;
@@ -76,12 +77,21 @@ fn main() -> Result<(), Error> {
 
     let rtsp = &RtspServer::new();
 
+    if ! config.certificate.is_empty() {
+        let tls_client_auth = match &config.tls_client_auth as &str {
+            "request" => TlsAuthenticationMode::Requested,
+            "require" => TlsAuthenticationMode::Required,
+            "none"|_ => TlsAuthenticationMode::None,
+        };
+        rtsp.set_tls(&config.certificate, tls_client_auth).expect("Failed to set up TLS");
+    }
+    
+
     crossbeam::scope(|s| {
         for camera in config.cameras {
             s.spawn(move |_| {
                 // TODO handle these errors
-                let cam_format :&str = &camera.format;
-                let stream_format = match cam_format {
+                let stream_format = match &camera.format as &str {
                     "h264"|"H264" => StreamFormat::H264,
                     "h265"|"H265" => StreamFormat::H265,
                     custom_format @ _ => StreamFormat::Custom(custom_format.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,14 +165,9 @@ fn set_up_users(users: &Vec<UserConfig>, rtsp: &RtspServer) {
         let user_pass = match (name, pass)  {
             (Some(name), Some(pass)) => {
                 Some((&name as &str, &pass as &str))
-            }
-            (Some(name), None) => {
-                warn!("One of the users has no password, skipping this user");
-                debug!("The skipped user was {}", name);
-                None
             },
-            (None, Some(_pass)) => {
-                warn!("One of the users has a password but no name, skipping this user");
+            (Some(_), None) | (None, Some(_)) => {
+                warn!("Username and password must be supplied together - ignoring [[users]] entry");
                 None
             },
             _ => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,15 @@ fn set_up_users(users: &Vec<UserConfig>, rtsp: &RtspServer) {
         let pass = &user.pass;
         let user_pass = match (name, pass)  {
             (Some(name), Some(pass)) => Some((&name as &str, &pass as &str)),
+            (Some(name), None) => {
+                warn!("One of the users has no password, skipping this user");
+                debug!("The skipped user was {}", name);
+                None
+            }
+            (None, Some(_pass)) => {
+                warn!("One of the users has a password but no name, skipping this user");
+                None
+            }
             _ => None,
         };
         credentials.push(user_pass);
@@ -172,7 +181,7 @@ fn get_permitted_users(users: &Vec<UserConfig>, current_permitted_users: &Vec<St
                 new_permitted_users.push(user.to_string());
             }
         }
-        new_permitted_users.push("unauth".to_string());
+        new_permitted_users.push("anonymous".to_string());
     } else {
         new_permitted_users.append(&mut current_permitted_users.clone());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,6 @@ fn main() -> Result<(), Error> {
         Ok(_) => (),
         Err(e) => return Err(Error::ValidationError(e)),
     };
-    for camera in &config.cameras {
-        match camera.validate() {
-            Ok(_) => (),
-            Err(e) => return Err(Error::ValidationError(e)),
-        };
-    }
 
     // Setup auto sub streams, we do this by looping the cameras
     // If the stream type is both we clone the config

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,15 +77,15 @@ fn main() -> Result<(), Error> {
 
     let rtsp = &RtspServer::new();
 
-    if ! config.certificate.is_empty() {
-        let tls_client_auth = match &config.tls_client_auth as &str {
-            "request" => TlsAuthenticationMode::Requested,
-            "require" => TlsAuthenticationMode::Required,
-            "none"|_ => TlsAuthenticationMode::None,
-        };
-        rtsp.set_tls(&config.certificate, tls_client_auth).expect("Failed to set up TLS");
-    }
-    
+    let tls_client_auth = match &config.tls_client_auth as &str {
+        "request" => TlsAuthenticationMode::Requested,
+        "require" => TlsAuthenticationMode::Required,
+        "none"|_ => TlsAuthenticationMode::None,
+    };
+    rtsp.set_tls(&config.certificate, tls_client_auth).expect("Failed to set up TLS");
+
+    rtsp.set_credentials(&config.username, &config.password).expect("Failed to set up users.");
+
 
     crossbeam::scope(|s| {
         for camera in config.cameras {

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ fn set_up_users(users: &Vec<UserConfig>, rtsp: &RtspServer) {
 fn get_permitted_users(
     users: &Vec<UserConfig>,
     permitted_users: &Option<Vec<String>>,
-) -> Vec<String> {
+) -> HashSet<String> {
     let current_permitted_users = match permitted_users {
         Some(permitted_users) => permitted_users.clone().to_owned(),
         None => {
@@ -209,11 +209,7 @@ fn get_permitted_users(
             new_permitted_users.insert(user.to_string());
         }
     }
-    let mut result = vec![];
-    for user in new_permitted_users {
-        result.push(user);
-    }
-    result
+    new_permitted_users
 }
 
 fn camera_main(

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,10 @@ fn main() -> Result<(), Error> {
         "none" => TlsAuthenticationMode::None,
         _ => unreachable!(),
     };
-    rtsp.set_tls(&config.certificate, tls_client_auth).expect("Failed to set up TLS");
+
+    if let Some(cert_path) = &config.certificate {
+        rtsp.set_tls(&cert_path, tls_client_auth).expect("Failed to set up TLS");
+    }
 
     let name = &config.username;
     let pass = &config.password;

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,8 @@ fn main() -> Result<(), Error> {
     let tls_client_auth = match &config.tls_client_auth as &str {
         "request" => TlsAuthenticationMode::Requested,
         "require" => TlsAuthenticationMode::Required,
-        "none"|_ => TlsAuthenticationMode::None,
+        "none" => TlsAuthenticationMode::None,
+        _ => unreachable!(),
     };
     rtsp.set_tls(&config.certificate, tls_client_auth).expect("Failed to set up TLS");
 


### PR DESCRIPTION
This PR adds both TLS and basic authentication.

- The TLS controlled by the configuration options.

  - Adding `certificate = "PATHTOCERT"` will enable TLS, without client auth.
  - Also adding `tls_client_auth = "none|requested|required"` will require that the client provide a certificate signed by the server's CA.
  - When TLS is enabled standard `rtsp` is disabled and all connections must be through `rtsps`

- The basic auth is controlled by the options
```
username = "someuser"
password = "somepass"
```
If both user and pass is not present it will not enable basic auth.

Currently this PR enables one user to access all content or none. I expect to add to more fine grained control later.

As before my rust is basic, sorry about that.

fixes #5