### PR TITLE
Dockerfile missing gst dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,13 @@ RUN cargo build --release
 # Create the release container. Match the base OS used to build
 FROM docker.io/alpine:latest
 
-RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing gst-rtsp-server
-RUN apk add libgcc
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing libgcc \
+  gstreamer \
+  gst-plugins-base \
+  gst-plugins-good \
+  gst-plugins-bad \
+  gst-plugins-ugly \
+  gst-rtsp-server
 
 COPY --from=build \
   /usr/local/src/neolink/target/release/neolink \


### PR DESCRIPTION
I wanted to use provided `Dockerfile`, but I got just `RTSP: media was configured` message. Neolink was successfully connected to camera, according to logs, but RTSP stream was just not responing.

Also, I encountered error message `Failed to create element 'rtpbin'` and was able to figure out, that gst dependencies are clearly missing:

* Main [gstreamer](https://pkgs.alpinelinux.org/package/edge/main/s390x/gstreamer) package was missing.
* In [gst-plugins-base](https://gstreamer.freedesktop.org/modules/gst-plugins-base.html) package, there seems to be essential helper functions used across codebase.
* [rtpbin](https://gstreamer.freedesktop.org/documentation/rtpmanager/rtpbin.html) is in [gst-plugins-good](https://gstreamer.freedesktop.org/modules/gst-plugins-good.html) package.
* [H265](https://gstreamer.freedesktop.org/documentation/x265/index.html) is in [gst-plugins-bad](https://gstreamer.freedesktop.org/modules/gst-plugins-bad.html) package.
* [H264](https://gstreamer.freedesktop.org/documentation/x264/index.html) is in [gst-plugins-ugly](https://gstreamer.freedesktop.org/modules/gst-plugins-ugly.html) package.

Now it's working everything like charm in Docker. Keep up good work!