### PR TITLE
Add a build action for armhf

### DIFF
--- a/.github/workflows/armhf.yml
+++ b/.github/workflows/armhf.yml
@@ -1,0 +1,51 @@
+name: Build ARMHF
+
+on: [push, pull_request]
+
+jobs:
+  armhfbuild:
+    name: build-armhf
+    runs-on: ubuntu-latest
+    container: node:current-buster-slim
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install basic tools
+        run: |
+          apt-get update
+          apt-get install --assume-yes --no-install-recommends sudo curl ca-certificates build-essential
+      - name: Add armhf as a foreign architecture
+        run: |
+          sudo dpkg --add-architecture armhf
+      - name: Install cross compile tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends gcc-arm-linux-gnueabihf
+      - name: Install armhf gstreamer
+        run: |
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends \
+          libgstrtspserver-1.0-dev:armhf \
+          libgstreamer1.0-dev:armhf \
+          libgtk2.0-dev:armhf
+      - name: Install rustup armv7
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+            target: armv7-unknown-linux-gnueabihf
+      - name: Build armfh
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features --target=armv7-unknown-linux-gnueabihf
+        env:
+          CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+          CC_armv7_unknown_linux_gnueabihf: arm-linux-gnueabihf-gcc
+          CXX_armv7_unknown_linux_gnueabihf: arm-linux-gnueabihf-g++
+          PKG_CONFIG_ALLOW_CROSS: 1
+          PKG_CONFIG_PATH: /usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig/
+          PKG_CONFIG_LIBDIR: /usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: release-armhf
+          path: "target/armv7-unknown-linux-gnueabihf/release/neolink*"


### PR DESCRIPTION
So this PR adds a build action for armhf

It is mostly build off of [cargo cross](https://github.com/rust-embedded/cross) which is a very nice way of cross compiling rust projects

The default docker image for armhf from `cross` was however not working for us (because of the gstreamer dependencies) so I had to build a new docker based off of the one from cargo cross.

Currently the docker image is built *EVERY* time the action is run. Which is not ideal, really it should be published and then pulled when needed since that that part never changes. But I thought I would put the PR here so you can see what you think before I try anything else more complex.

fix #27 (well armv7 anyways)