### PR TITLE
Use an Arc Mutex to set the clock only once

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use validator::{Validate, ValidationError};
 use validator_derive::Validate;
+use std::sync::{Arc, Mutex};
 
 lazy_static! {
     static ref RE_STREAM_FORM: Regex = Regex::new(r"^([hH]26[45]|[ \t]*[!].*)$").unwrap();
@@ -13,7 +14,7 @@ lazy_static! {
     static ref RE_TLS_CLIENT_AUTH: Regex = Regex::new(r"^(none|request|require)$").unwrap();
 }
 
-#[derive(Debug, Deserialize, Validate, Clone)]
+#[derive(Debug, Deserialize, Validate)]
 pub struct Config {
     #[validate]
     pub cameras: Vec<CameraConfig>,
@@ -41,7 +42,7 @@ pub struct Config {
     pub users: Vec<UserConfig>,
 }
 
-#[derive(Debug, Deserialize, Validate, Clone)]
+#[derive(Debug, Deserialize, Validate)]
 pub struct CameraConfig {
     pub name: String,
 
@@ -71,6 +72,9 @@ pub struct CameraConfig {
     pub stream: String,
 
     pub permitted_users: Option<Vec<String>>,
+
+    #[serde(skip, default = "default_time_set")]
+    pub time_has_been_set: Arc<Mutex<bool>>,
 }
 
 #[derive(Debug, Deserialize, Validate, Clone)]
@@ -105,6 +109,10 @@ fn default_certificate() -> Option<String> {
 
 fn default_tls_client_auth() -> String {
     "none".to_string()
+}
+
+fn default_time_set() -> Arc<Mutex<bool>> {
+    Arc::new(Mutex::new(false))
 }
 
 pub static RESERVED_NAMES: &[&str] = &["anyone", "anonymous"];

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use validator::{Validate, ValidationError};
 use validator_derive::Validate;
-use std::sync::{Arc, Mutex};
 
 lazy_static! {
     static ref RE_STREAM_FORM: Regex = Regex::new(r"^([hH]26[45]|[ \t]*[!].*)$").unwrap();
@@ -14,7 +13,7 @@ lazy_static! {
     static ref RE_TLS_CLIENT_AUTH: Regex = Regex::new(r"^(none|request|require)$").unwrap();
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, Clone)]
 pub struct Config {
     #[validate]
     pub cameras: Vec<CameraConfig>,
@@ -42,7 +41,7 @@ pub struct Config {
     pub users: Vec<UserConfig>,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, Clone)]
 pub struct CameraConfig {
     pub name: String,
 
@@ -72,9 +71,6 @@ pub struct CameraConfig {
     pub stream: String,
 
     pub permitted_users: Option<Vec<String>>,
-
-    #[serde(skip, default = "default_time_set")]
-    pub time_has_been_set: Arc<Mutex<bool>>,
 }
 
 #[derive(Debug, Deserialize, Validate, Clone)]
@@ -109,10 +105,6 @@ fn default_certificate() -> Option<String> {
 
 fn default_tls_client_auth() -> String {
     "none".to_string()
-}
-
-fn default_time_set() -> Arc<Mutex<bool>> {
-    Arc::new(Mutex::new(false))
 }
 
 pub static RESERVED_NAMES: &[&str] = &["anyone", "anonymous"];

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,36 +218,27 @@ fn camera_main(
         connected = true;
         info!("{}: Connected and logged in", camera_config.name);
 
-        let mut lock_time = camera_config.time_has_been_set.try_lock();
-        // If we were able to get the lock do then set the time
-        // If not another thread is setting it now so just skip this
-        if let Ok(ref mut time_set) = lock_time {
-            // Check if its been set on another thead already
-            if ! **time_set {
-                    **time_set = true;
-                let cam_time = camera.get_time()?;
-                if let Some(time) = cam_time {
-                    info!(
-                        "{}: Camera time is already set: {}",
-                        camera_config.name, time
-                    );
-                } else {
-                    let new_time = time::OffsetDateTime::now_local();
-                    warn!(
-                        "{}: Camera has no time set, setting to {}",
-                        camera_config.name, new_time
-                    );
-                    camera.set_time(new_time)?;
-                    let cam_time = camera.get_time()?;
-                    if let Some(time) = cam_time {
-                        info!(
-                            "{}: Camera time is now set: {}",
-                            camera_config.name, time
-                        );
-                    } else {
-                        error!("{}: Camera did not accept new time (is {} an admin?)", camera_config.name, camera_config.username);
-                    }
-                }
+        let cam_time = camera.get_time()?;
+        if let Some(time) = cam_time {
+            info!(
+                "{}: Camera time is already set: {}",
+                camera_config.name, time
+            );
+        } else {
+            let new_time = time::OffsetDateTime::now_local();
+            warn!(
+                "{}: Camera has no time set, setting to {}",
+                camera_config.name, new_time
+            );
+            camera.set_time(new_time)?;
+            let cam_time = camera.get_time()?;
+            if let Some(time) = cam_time {
+                info!(
+                    "{}: Camera time is now set: {}",
+                    camera_config.name, time
+                );
+            } else {
+                error!("{}: Camera did not accept new time (is {} an admin?)", camera_config.name, camera_config.username);
             }
         }
 


### PR DESCRIPTION
Here is an attempt at setting the clock only once per camera.

It is my first foray into cross thread locking in rust so I hope I got it right. I mostly just followed the [docs](https://doc.rust-lang.org/std/sync/struct.Mutex.html) on `Arc<Mutex>`.

It works by creating a `Arc<Mutex<bool>>` in the camera config (with serde=skip so that it cannot be set in the config file). I use try_lock() to attempt to lock it and if successful it goes on to set the time, if unable to lock it just skips the time setting code entirely.


closes #57 