### PR TITLE
Allow setting channel_id

### DIFF
--- a/src/bc_protocol.rs
+++ b/src/bc_protocol.rs
@@ -244,7 +244,7 @@ impl BcCamera {
         Ok(())
     }
 
-    pub fn start_video(&self, data_out: &mut dyn Write, stream_name: &str) -> Result<Never> {
+    pub fn start_video(&self, data_out: &mut dyn Write, stream_name: &str, channel_id: u32) -> Result<Never> {
         let connection = self
             .connection
             .as_ref()
@@ -261,7 +261,7 @@ impl BcCamera {
             BcXml {
                 preview: Some(Preview {
                     version: xml_ver(),
-                    channel_id: 0,
+                    channel_id: channel_id,
                     handle: 0,
                     stream_type: stream_name.to_string(),
                 }),

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,10 @@ pub struct CameraConfig {
     pub stream: String,
 
     pub permitted_users: Option<Vec<String>>,
+
+    #[validate(range(min = 0, max = 31, message = "Invalid channel", code = "channel_id"))]
+    #[serde(default = "default_channel_id")]
+    pub channel_id: u32,
 }
 
 #[derive(Debug, Deserialize, Validate, Clone)]
@@ -105,6 +109,10 @@ fn default_certificate() -> Option<String> {
 
 fn default_tls_client_auth() -> String {
     "none".to_string()
+}
+
+fn default_channel_id() -> u32 {
+    0
 }
 
 pub static RESERVED_NAMES: &[&str] = &["anyone", "anonymous"];

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,7 @@ fn camera_main(
             "{}: Starting video stream {}",
             camera_config.name, stream_name
         );
-        camera.start_video(output, stream_name)
+        camera.start_video(output, stream_name, camera_config.channel_id)
     })()
     .map_err(|err| CameraErr { connected, err })
 }


### PR DESCRIPTION
This allows setting the channel_id in the config file.

Eg:
[[cameras]]
name = "test0"
address = "192.168.1.2:9000"
channel_id = 0

[[cameras]]
name = "test2"
username = "admin"
address = "192.168.1.2:9000"
channel_id = 2