### PR TITLE
More detailed error messages on deser fail and timeout

### DIFF
--- a/src/bc_protocol.rs
+++ b/src/bc_protocol.rs
@@ -47,16 +47,25 @@ pub enum Error {
     DroppedConnection(#[error(source)] std::sync::mpsc::RecvError),
 
     #[error(display = "Timeout")]
-    Timeout(#[error(source)] std::sync::mpsc::RecvTimeoutError),
+    Timeout,
 
-    #[error(display = "Media")]
-    MediaPacket(#[error(source)] self::media_packet::Error),
+    #[error(display = "Dropped connection")]
+    TimeoutDisconnected,
 
     #[error(display = "Credential error")]
     AuthFailed,
 
     #[error(display = "Other error")]
     Other(&'static str),
+}
+
+impl<'a> From<std::sync::mpsc::RecvTimeoutError> for Error {
+    fn from(k: std::sync::mpsc::RecvTimeoutError) -> Self {
+        match k {
+            std::sync::mpsc::RecvTimeoutError::Timeout => Error::Timeout,
+            std::sync::mpsc::RecvTimeoutError::Disconnected => Error::TimeoutDisconnected,
+        }
+    }
 }
 
 impl Drop for BcCamera {

--- a/src/bc_protocol/connection.rs
+++ b/src/bc_protocol/connection.rs
@@ -55,7 +55,15 @@ impl BcConnection {
 
         let rx_thread = std::thread::spawn(move || {
             let mut context = BcContext::new();
-            while BcConnection::poll(&mut context, &conn, &mut subs).is_ok() {}
+            while {
+                match BcConnection::poll(&mut context, &conn, &mut subs) {
+                    Ok(_) => true,
+                    Err(err) => {
+                        error!("Deserialization error: {}", err);
+                        false
+                    }
+                }
+            } {}
         });
 
         Ok(BcConnection {

--- a/src/bc_protocol/connection.rs
+++ b/src/bc_protocol/connection.rs
@@ -59,7 +59,7 @@ impl BcConnection {
                 match BcConnection::poll(&mut context, &conn, &mut subs) {
                     Ok(_) => true,
                     Err(err) => {
-                        error!("Deserialization error: {}", err);
+                        error!("Deserialization error: {:?}", err);
                         false
                     }
                 }

--- a/src/bc_protocol/connection.rs
+++ b/src/bc_protocol/connection.rs
@@ -55,15 +55,12 @@ impl BcConnection {
 
         let rx_thread = std::thread::spawn(move || {
             let mut context = BcContext::new();
+            let mut result;
             while {
-                match BcConnection::poll(&mut context, &conn, &mut subs) {
-                    Ok(_) => true,
-                    Err(err) => {
-                        error!("Deserialization error: {:?}", err);
-                        false
-                    }
-                }
+                result = BcConnection::poll(&mut context, &conn, &mut subs);
+                result.is_ok()
             } {}
+            error!("Deserialization error: {:?}", result.unwrap_err());
         });
 
         Ok(BcConnection {

--- a/src/bc_protocol/media_packet.rs
+++ b/src/bc_protocol/media_packet.rs
@@ -1,6 +1,6 @@
 use crate::bc::model::*;
 use crate::bc_protocol::connection::BcSubscription;
-use err_derive::Error;
+use crate::Error;
 use log::trace;
 use log::*;
 use std::collections::VecDeque;
@@ -16,12 +16,6 @@ const MAGIC_SIZE: usize = 4;
 const PAD_SIZE: usize = 8;
 
 type Result<T> = std::result::Result<T, Error>;
-
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error(display = "Timeout")]
-    Timeout(#[error(source)] std::sync::mpsc::RecvTimeoutError),
-}
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum MediaDataKind {


### PR DESCRIPTION
While I was making changes to the deserialiser I noticed that any errors during derserialisation would be silently ignored. Instead it would just drop the connection and restart.

This makes changes so that it prints the error prior to dropping and restarting the connection.

I also noticed that the error `std::sync::mpsc::RecvTimeoutError` is actually an enum of, `Timeout` or `Disconnected` but in the code we treat them the same as `Timeout` (this is why sometimes it would say timeout error even when the the 5 seconds (of `RX_TIMEOUT`) had yet to pass)

This also makes changes to the `Error` enum so that we correctly distinguish between the two.