### PR TITLE
Transcode audio to PCM for all even for AAC

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,8 @@ jobs:
           choco install -y --no-progress gstreamer --version=1.16.2.20200527
           choco install -y --no-progress gstreamer-devel --version=1.16.2
           echo "Updating Cargo environment"
-          echo "::add-path::C:\gstreamer\1.0\x86_64\bin"
-          echo "::set-env name=GSTREAMER_1_0_ROOT_X86_64::C:\gstreamer\1.0\x86_64\"
+          echo "C:\gstreamer\1.0\x86_64\bin" >> $GITHUB_PATH
+          echo "GSTREAMER_1_0_ROOT_X86_64=C:\gstreamer\1.0\x86_64\" >> $GITHUB_ENV
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,8 @@ jobs:
           choco install -y --no-progress gstreamer --version=1.16.2.20200527
           choco install -y --no-progress gstreamer-devel --version=1.16.2
           echo "Updating Cargo environment"
-          echo "C:\gstreamer\1.0\x86_64\bin" >> $GITHUB_PATH
-          echo "GSTREAMER_1_0_ROOT_X86_64=C:\gstreamer\1.0\x86_64\" >> $GITHUB_ENV
+          echo "C:\gstreamer\1.0\x86_64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "GSTREAMER_1_0_ROOT_X86_64=C:\gstreamer\1.0\x86_64\" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -86,7 +86,7 @@ impl GstOutputs {
 
         let launch_aud = match self.audio_format {
             Some(StreamFormat::ADPCM) => "! queue silent=true max-size-bytes=10485760 min-threshold-bytes=1024 ! rawaudioparse format=pcm pcm-format=s16le sample-rate=8000 num-channels=1 interleaved=true ! audioconvert ! rtpL16pay name=pay1", // DVI4 is converted to pcm in the appsrc
-            Some(StreamFormat::AAC) => "! queue silent=true max-size-bytes=10485760 min-threshold-bytes=1024 ! aacparse ! decodebin ! audioconvert ! rtpmp4apay name=pay1",
+            Some(StreamFormat::AAC) => "! queue silent=true max-size-bytes=10485760 min-threshold-bytes=1024 ! aacparse ! decodebin ! audioconvert ! rtpL16pay name=pay1 name=pay1",
             _ => "! fakesink",
         };
 

--- a/src/gst.rs
+++ b/src/gst.rs
@@ -86,7 +86,7 @@ impl GstOutputs {
 
         let launch_aud = match self.audio_format {
             Some(StreamFormat::ADPCM) => "! queue silent=true max-size-bytes=10485760 min-threshold-bytes=1024 ! rawaudioparse format=pcm pcm-format=s16le sample-rate=8000 num-channels=1 interleaved=true ! audioconvert ! rtpL16pay name=pay1", // DVI4 is converted to pcm in the appsrc
-            Some(StreamFormat::AAC) => "! queue silent=true max-size-bytes=10485760 min-threshold-bytes=1024 ! aacparse ! rtpmp4apay name=pay1",
+            Some(StreamFormat::AAC) => "! queue silent=true max-size-bytes=10485760 min-threshold-bytes=1024 ! aacparse ! decodebin ! audioconvert ! rtpmp4apay name=pay1",
             _ => "! fakesink",
         };
 


### PR DESCRIPTION
We have issues with aac audio on the lumus camera. This is because the Lumus camera uses `audio/mpeg version=2` for audio, while our current implementation is for `audio/mpeg version=4`. Since gstreamer lacks an rtp plugin for `audio/mpeg version=2` and because theres no easy way to detect if the audio is `audio/mpeg version=2` or `audio/mpeg version=4` I propose we simple always transcode to PCM.

This PR also fixes the broken windows build as raised in issue #89 

fixes #89 #88 