### PR TITLE
config: allow hostnames for camera addresses

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,6 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Deserialize;
 use std::clone::Clone;
-use std::net::SocketAddr;
 use std::time::Duration;
 use validator::{Validate, ValidationError};
 use validator_derive::Validate;
@@ -45,7 +44,7 @@ pub struct CameraConfig {
     pub name: String,
 
     #[serde(rename = "address")]
-    pub camera_addr: SocketAddr,
+    pub camera_addr: String,
 
     pub username: String,
     pub password: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,7 +198,6 @@ fn camera_main(
 ) -> Result<Never, CameraErr> {
     let mut connected = false;
     (|| {
-        let mut camera = BcCamera::new_with_addr(camera_config.camera_addr)?;
         if camera_config.timeout.is_some() {
             warn!("The undocumented `timeout` config option has been removed and is no longer needed.");
             warn!("Please update your config file.");
@@ -208,7 +207,8 @@ fn camera_main(
             "{}: Connecting to camera at {}",
             camera_config.name, camera_config.camera_addr
         );
-        camera.connect()?;
+
+        let mut camera = BcCamera::connect(&camera_config.camera_addr)?;
 
         camera.login(&camera_config.username, camera_config.password.as_deref())?;
 


### PR DESCRIPTION
This offers more flexibility, as a camera system admin only
needs a DNS assignment rather than DHCP. The syntax is still
as expected:

address = "cameras.example.com:9000"

This is especially handy in more complex topologies, where one
or more specified "camera" may actually be pointed at a system
providing a tunnel through to multiple cameras; names make it
easier to identify said gateway machine.

All IPs that the given name resolves to are tried so that we
correctly handle, e.g., a name with both AAAA and A records.

Note that addresses are no longer validated up front, but instead
simply get resolved when the connection attempt is made.

Name resolution will be aborted after ~60s of failure.

Note that my camera setup is not yet complete, so this was only tested against:
- Non-existent IP
- Unresolvable hostname
- localhost w/ port closed
- localhost w/ port open

All of these behave as expected. Please excuse my rust, as I'm quite new at it.