### PR TITLE
Three stage docker and armv7/v6

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,12 +29,48 @@ jobs:
         uses: ASzc/change-string-case-action@v1
         with:
           string: ${{ github.repository }}
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+      - name: Set up QEMU
         if: ${{ steps.vars.outputs.HAS_SECRET_TOKEN }}
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        if: ${{ steps.vars.outputs.HAS_SECRET_TOKEN }}
+        uses: docker/setup-buildx-action@v1
+      - name: Login to dockerhub
+        if: ${{ steps.vars.outputs.HAS_SECRET_TOKEN }}
+        uses: docker/login-action@v1
         with:
           username: ${{ steps.string_user.outputs.lowercase }}
           password: ${{ secrets.DOCKER_TOKEN }}
-          registry: docker.io
-          repository: ${{ steps.string_repo.outputs.lowercase }}
-          tag_with_ref: true
+      - name: Get tag name
+        if: ${{ steps.vars.outputs.HAS_SECRET_TOKEN }}
+        id: tags
+        run: |
+          branch="${GITHUB_REF#refs/heads/}"
+          tags="${REPO_NAME}:${branch}"
+          if [ "${branch}" == "master" ]; then
+            tags="${tags},${REPO_NAME}:latest"
+          fi
+          echo "::set-output name=TAGS::${tags}"
+        env:
+          REPO_NAME: ${{ steps.string_repo.outputs.lowercase }}
+      - name: Install toml-cli
+        uses: actions-rs/install@v0.1
+        with:
+          crate: toml-cli
+          version: latest
+      - name: Get project version
+        id: toml
+        run: |
+          NEOLINK_VERSION="$(toml get Cargo.toml  package.version | sed 's|"||g')"
+          echo "::set-output name=version::${NEOLINK_VERSION}"
+      - name: Push to Docker Hub
+        if: ${{ steps.vars.outputs.HAS_SECRET_TOKEN }}
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.tags.outputs.TAGS }}
+          build-args: VERSION=${{ steps.toml.outputs.version }}, REPO=${{ github.repository }}, OWNER=${{ github.repository_owner }}
+        env:
+          DOCKER_BUILDKIT: 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ steps.vars.outputs.HAS_SECRET_TOKEN }}
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm/v7,linux/arm/v6
           push: true
           file: Dockerfile
           tags: ${{ steps.tags.outputs.TAGS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@
 #################################
 ##            SETUP            ##
 #################################
+# This is the generic base for  #
+# all other dockers to follow   #
+#################################
 FROM docker.io/alpine:edge AS setup
 ARG TARGETPLATFORM
 
@@ -20,6 +23,9 @@ RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing libg
 
 #################################
 ##            BUILD            ##
+#################################
+# Install dev packages and      #
+# with cargo                    #
 #################################
 FROM setup AS build
 ARG TARGETPLATFORM
@@ -46,7 +52,9 @@ RUN cargo build --release
 #################################
 ##            PUBLISH          ##
 #################################
-# Create the release container. Match the base OS used to build
+# Copy from build neolink and   #
+# prepares for execution        #
+#################################
 FROM setup
 ARG TARGETPLATFORM
 ARG REPO

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,11 @@
 # Copyright (c) 2020 George Hilliard
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM docker.io/rust:1-alpine AS build
-MAINTAINER thirtythreeforty@gmail.com
-
-# Until Alpine merges gst-rtsp-server into a release, pull all Gstreamer packages
-# from the "testing" release
-RUN apk add --no-cache \
-    -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
-    -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-  gst-rtsp-server-dev
-RUN apk add --no-cache musl-dev gcc
-
-# Use static linking to work around https://github.com/rust-lang/rust/pull/58575
-ENV RUSTFLAGS='-C target-feature=-crt-static'
-
-WORKDIR /usr/local/src/neolink
-
-# Build the main program
-COPY . /usr/local/src/neolink
-RUN cargo build --release
-
-# Create the release container. Match the base OS used to build
-FROM docker.io/alpine:latest
+#################################
+##            SETUP            ##
+#################################
+FROM docker.io/alpine:edge AS setup
+ARG TARGETPLATFORM
 
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing libgcc \
   tzdata \
@@ -34,11 +17,54 @@ RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing libg
   gst-plugins-ugly \
   gst-rtsp-server
 
+
+#################################
+##            BUILD            ##
+#################################
+FROM setup AS build
+ARG TARGETPLATFORM
+
+# Until Alpine merges gst-rtsp-server into a release, pull all Gstreamer packages
+# from the "testing" release
+RUN apk add --no-cache \
+    -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
+    -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+  gst-rtsp-server-dev
+RUN apk add --no-cache musl-dev gcc
+RUN apk add --no-cache rust cargo
+
+# Use static linking to work around https://github.com/rust-lang/rust/pull/58575
+ENV RUSTFLAGS='-C target-feature=-crt-static'
+
+WORKDIR /usr/local/src/neolink
+
+# Build the main program
+COPY . /usr/local/src/neolink
+RUN cargo build --release
+
+
+#################################
+##            PUBLISH          ##
+#################################
+# Create the release container. Match the base OS used to build
+FROM setup
+ARG TARGETPLATFORM
+ARG REPO
+ARG VERSION
+ARG OWNER
+
+LABEL description="An image for the neolink program which is a reolink camera to rtsp translator"
+LABEL repository="$REPO"
+LABEL version="$VERSION"
+LABEL maintainer="$OWNER"
+
 COPY --from=build \
   /usr/local/src/neolink/target/release/neolink \
   /usr/local/bin/neolink
+
 COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 CMD ["/usr/local/bin/neolink", "--config", "/etc/neolink.toml"]
 ENTRYPOINT ["/entrypoint.sh"]
-EXPOSE 8554 
+EXPOSE 8554


### PR DESCRIPTION
This creates the three stage docker you suggested in #104 and and also builds a multi arch docker image with amd64/armv7 and armv6.

The issue with getting armv6 previously is mitigated by dropping armv8. It seems that the github hosted machines only have 2cpus and limited ram so building 4 archs at once is too much but three is possible. I have chosen armv6 and armv7 over armv7 and armv8 as these are the ones on rpis.

closes #104 #76 #84 #73 