### PR TITLE
Report firmware version after login

### DIFF
--- a/src/bc/model.rs
+++ b/src/bc/model.rs
@@ -5,6 +5,7 @@ pub(super) const MAGIC_HEADER: u32 = 0xabcdef0;
 
 pub const MSG_ID_LOGIN: u32 = 1;
 pub const MSG_ID_VIDEO: u32 = 3;
+pub const MSG_ID_VERSION: u32 = 80;
 pub const MSG_ID_PING: u32 = 93;
 pub const MSG_ID_GET_GENERAL: u32 = 104;
 pub const MSG_ID_SET_GENERAL: u32 = 105;

--- a/src/bc/xml.rs
+++ b/src/bc/xml.rs
@@ -35,6 +35,8 @@ pub struct BcXml {
     pub login_net: Option<LoginNet>,
     #[yaserde(rename = "DeviceInfo")]
     pub device_info: Option<DeviceInfo>,
+    #[yaserde(rename = "VersionInfo")]
+    pub version_info: Option<VersionInfo>,
     #[yaserde(rename = "Preview")]
     pub preview: Option<Preview>,
     #[yaserde(rename = "SystemGeneral")]
@@ -101,6 +103,17 @@ impl Default for LoginNet {
 #[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
 pub struct DeviceInfo {
     pub resolution: Resolution,
+}
+
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct VersionInfo {
+    pub name: String,
+    pub serialNumber: String,
+    pub buildDay: String,
+    pub hardwareVersion: String,
+    pub cfgVersion: String,
+    pub firmwareVersion: String,
+    pub detail: String,
 }
 
 #[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]

--- a/src/bc_protocol/adpcm.rs
+++ b/src/bc_protocol/adpcm.rs
@@ -225,7 +225,7 @@ pub fn adpcm_to_pcm(bytes: &[u8]) -> Result<Vec<u8>, Error> {
                 // Some formats e.g. OKI are not in the full PCM range of values
                 // To convert we must scale it to the i16 range
                 // We also cast to i16 at this point ready for the conversion to u8 bytes of the output
-                let scaled_sample = (sample as i32 * (i16::MAX as i32)
+                let scaled_sample = (sample as i32 * (std::i16::MAX as i32)
                     / (context.max_sample_size - 1) as i32)
                     as i16;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,12 +261,15 @@ fn do_camera_management(
         }
     }
 
-    let version_info = camera.version();
-    if version_info.is_ok() {
+    use neolink::bc::xml::VersionInfo;
+    if let Ok(VersionInfo {
+        firmwareVersion: firmware_version,
+        ..
+    }) = camera.version()
+    {
         info!(
             "{}: Camera reports firmware version {}",
-            camera_config.name,
-            version_info.unwrap().firmwareVersion
+            camera_config.name, firmware_version
         );
     } else {
         info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,5 +260,20 @@ fn do_camera_management(
             );
         }
     }
+
+    let version_info = camera.version();
+    if version_info.is_ok() {
+        info!(
+            "{}: Camera reports firmware version {}",
+            camera_config.name,
+            version_info.unwrap().firmwareVersion
+        );
+    } else {
+        info!(
+            "{}: Could not fetch version information",
+            camera_config.name
+        );
+    }
+
     Ok(())
 }


### PR DESCRIPTION
This is useful information to have when you have no intention of starting up the official client any day soon to check.