### PR TITLE
Single login streams

### DIFF
--- a/crates/core/src/bc/de.rs
+++ b/crates/core/src/bc/de.rs
@@ -169,8 +169,7 @@ fn bc_modern_msg<'a, 'b>(
     };
 
     // Now we'll take the buffer that Nom gave a ref to and parse it.
-    let extension;
-    if ext_len > 0 {
+    let extension = if ext_len > 0 {
         // Apply the XML parse function, but throw away the reference to decrypted in the Ok and
         // Err case. This error-error-error thing is the same idiom Nom uses internally.
         let parsed = Extension::try_parse(processed_ext_buf)
@@ -182,10 +181,10 @@ fn bc_modern_msg<'a, 'b>(
         {
             context.in_bin_mode.insert(header.msg_num);
         }
-        extension = Some(parsed);
+        Some(parsed)
     } else {
-        extension = None;
-    }
+        None
+    };
 
     // Now to handle the payload block
     // This block can either be xml or binary depending on what the message expects.

--- a/crates/core/src/bc/model.rs
+++ b/crates/core/src/bc/model.rs
@@ -10,6 +10,8 @@ pub const MSG_ID_LOGIN: u32 = 1;
 pub const MSG_ID_LOGOUT: u32 = 2;
 /// Video and Audio Streams messages have this ID
 pub const MSG_ID_VIDEO: u32 = 3;
+/// Video and Audio Streams messages have this ID when a stop is requested
+pub const MSG_ID_VIDEO_STOP: u32 = 4;
 /// TalkAbility messages have this ID
 pub const MSG_ID_TALKABILITY: u32 = 10;
 /// TalkReset messages have this ID

--- a/crates/core/src/bc/ser.rs
+++ b/crates/core/src/bc/ser.rs
@@ -173,7 +173,7 @@ where
 
 /// A serializer combinator that does nothing with its input
 fn do_nothing<W>() -> impl SerializeFn<W> {
-    move |out: WriteContext<W>| Ok(out)
+    Ok
 }
 
 #[test]

--- a/crates/core/src/bc/ser.rs
+++ b/crates/core/src/bc/ser.rs
@@ -164,7 +164,7 @@ where
 {
     move |buf: WriteContext<W>| {
         if let Some(ref val) = opt {
-            ser(&*val)(buf)
+            ser(val)(buf)
         } else {
             do_nothing()(buf)
         }

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -12,6 +12,7 @@ use indoc::indoc;
 /// There are two types of payloads xml and binary
 #[derive(PartialEq, Eq, Debug, YaDeserialize)]
 #[yaserde(flatten)]
+#[allow(clippy::large_enum_variant)]
 pub enum BcPayloads {
     /// XML payloads are the more common ones and include payloads for camera controls
     #[yaserde(rename = "body")]

--- a/crates/core/src/bc_protocol.rs
+++ b/crates/core/src/bc_protocol.rs
@@ -31,7 +31,7 @@ pub use stream::{Stream, StreamOutput, StreamOutputError};
 
 type Result<T> = std::result::Result<T, Error>;
 
-impl<'a> From<std::sync::mpsc::RecvTimeoutError> for Error {
+impl From<std::sync::mpsc::RecvTimeoutError> for Error {
     fn from(k: std::sync::mpsc::RecvTimeoutError) -> Self {
         match k {
             std::sync::mpsc::RecvTimeoutError::Timeout => Error::Timeout,

--- a/crates/core/src/bc_protocol/connection/bcconn.rs
+++ b/crates/core/src/bc_protocol/connection/bcconn.rs
@@ -14,8 +14,8 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 /// A shareable connection to a camera.  Handles serialization of messages.  To send/receive, call
-/// .[subscribe()] with a message ID.  You can use the BcSubscription to send or receive only
-/// messages with that ID; each incoming message is routed to its appropriate subscriber.
+/// .[subscribe()] with a message number.  You can use the BcSubscription to send or receive only
+/// messages with that number; each incoming message is routed to its appropriate subscriber.
 ///
 /// There can be only one subscriber per kind of message at a time.
 pub struct BcConnection {

--- a/crates/core/src/bc_protocol/connection/bcconn.rs
+++ b/crates/core/src/bc_protocol/connection/bcconn.rs
@@ -96,6 +96,7 @@ impl BcConnection {
         Ok(())
     }
 
+    #[allow(clippy::significant_drop_in_scrutinee)]
     pub fn subscribe(&self, msg_num: u16) -> Result<BcSubscription> {
         let (tx, rx) = channel();
         match self.subscribers.lock().unwrap().entry(msg_num) {
@@ -126,6 +127,7 @@ impl BcConnection {
         self.sink.lock().unwrap().is_udp()
     }
 
+    #[allow(clippy::significant_drop_in_scrutinee)]
     fn poll(
         context: &mut BcContext,
         connection: &BcSource,

--- a/crates/core/src/bc_protocol/connection/bcsub.rs
+++ b/crates/core/src/bc_protocol/connection/bcsub.rs
@@ -4,17 +4,17 @@ use std::sync::mpsc::Receiver;
 
 pub struct BcSubscription<'a> {
     pub rx: Receiver<Bc>,
-    msg_id: u32,
+    msg_num: u16,
     conn: &'a BcConnection,
 }
 
 impl<'a> BcSubscription<'a> {
-    pub fn new(rx: Receiver<Bc>, msg_id: u32, conn: &'a BcConnection) -> BcSubscription<'a> {
-        BcSubscription { rx, msg_id, conn }
+    pub fn new(rx: Receiver<Bc>, msg_num: u16, conn: &'a BcConnection) -> BcSubscription<'a> {
+        BcSubscription { rx, msg_num, conn }
     }
 
     pub fn send(&self, bc: Bc) -> Result<()> {
-        assert!(bc.meta.msg_id == self.msg_id);
+        assert!(bc.meta.msg_num == self.msg_num);
         self.conn.send(bc)?;
         Ok(())
     }
@@ -24,6 +24,6 @@ impl<'a> BcSubscription<'a> {
 impl<'a> Drop for BcSubscription<'a> {
     fn drop(&mut self) {
         // It's fine if we can't unsubscribe as that means we already have
-        let _ = self.conn.unsubscribe(self.msg_id);
+        let _ = self.conn.unsubscribe(self.msg_num);
     }
 }

--- a/crates/core/src/bc_protocol/connection/mod.rs
+++ b/crates/core/src/bc_protocol/connection/mod.rs
@@ -55,7 +55,7 @@ pub enum Error {
     UdpSerialization(#[error(source)] bcudp::ser::Error),
 
     #[error(display = "Simultaneous subscription")]
-    SimultaneousSubscription { msg_id: u32 },
+    SimultaneousSubscription { msg_num: u16 },
 
     #[error(display = "Timeout")]
     Timeout,

--- a/crates/core/src/bc_protocol/connection/udpconn/discover.rs
+++ b/crates/core/src/bc_protocol/connection/udpconn/discover.rs
@@ -40,12 +40,11 @@ impl UdpDiscover {
 
         let addrs: Vec<SocketAddr> = addrs
             .iter()
-            .map(|a| {
+            .flat_map(|a| {
                 a.to_socket_addrs()
                     .ok()
                     .and_then(|mut a_iter| a_iter.next())
             })
-            .flatten()
             .collect();
 
         let mut bytes_send = 0;
@@ -120,13 +119,12 @@ impl UdpDiscover {
         let ports: [u16; 2] = [2015, 2018];
         let destinations: Vec<(Ipv4Addr, u16)> = broadcasts
             .iter()
-            .map(|&addr| {
+            .flat_map(|&addr| {
                 ports
                     .iter()
                     .map(|&port| (addr, port))
                     .collect::<Vec<(Ipv4Addr, u16)>>()
             })
-            .flatten()
             .collect();
         debug!("Broadcasting to: {:?}", destinations);
 

--- a/crates/core/src/bc_protocol/connection/udpconn/transmit.rs
+++ b/crates/core/src/bc_protocol/connection/udpconn/transmit.rs
@@ -288,6 +288,7 @@ impl UdpTransmit {
         Ok(())
     }
 
+    #[allow(clippy::significant_drop_in_scrutinee)]
     pub fn poll_write(
         &self,
         socket: &UdpSocket,

--- a/crates/core/src/bc_protocol/errors.rs
+++ b/crates/core/src/bc_protocol/errors.rs
@@ -38,6 +38,10 @@ pub enum Error {
         why: &'static str,
     },
 
+    /// Raised when the camera responds with a status code over than OK
+    #[error(display = "Camera responded with Service Unavaliable")]
+    CameraServiceUnavaliable,
+
     /// Raised when a connection is dropped.
     #[error(display = "Dropped connection")]
     DroppedConnection(#[error(source)] std::sync::mpsc::RecvError),

--- a/crates/core/src/bc_protocol/ledstate.rs
+++ b/crates/core/src/bc_protocol/ledstate.rs
@@ -30,6 +30,9 @@ impl BcCamera {
 
         sub_get.send(get)?;
         let msg = sub_get.rx.recv_timeout(RX_TIMEOUT)?;
+        if msg.meta.response_code != 200 {
+            return Err(Error::CameraServiceUnavaliable);
+        }
 
         if let BcBody::ModernMsg(ModernMsg {
             payload:

--- a/crates/core/src/bc_protocol/ledstate.rs
+++ b/crates/core/src/bc_protocol/ledstate.rs
@@ -8,12 +8,13 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to get time");
-        let sub_get = connection.subscribe(MSG_ID_GET_LED_STATUS)?;
+        let msg_num = self.new_message_num();
+        let sub_get = connection.subscribe(msg_num)?;
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_GET_LED_STATUS,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 response_code: 0,
                 stream_type: 0,
                 class: 0x6414,
@@ -54,7 +55,9 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to get time");
-        let sub_set = connection.subscribe(MSG_ID_SET_LED_STATUS)?;
+
+        let msg_num = self.new_message_num();
+        let sub_set = connection.subscribe(msg_num)?;
 
         // led_version is a field recieved from the camera but not sent
         // we set to None to ensure we don't send it to the camera
@@ -63,7 +66,7 @@ impl BcCamera {
             meta: BcMeta {
                 msg_id: MSG_ID_SET_LED_STATUS,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 response_code: 0,
                 stream_type: 0,
                 class: 0x6414,

--- a/crates/core/src/bc_protocol/login.rs
+++ b/crates/core/src/bc_protocol/login.rs
@@ -13,7 +13,8 @@ impl BcCamera {
                 .connection
                 .as_ref()
                 .expect("Must be connected to log in");
-            let sub_login = connection.subscribe(MSG_ID_LOGIN)?;
+            let msg_num = self.new_message_num();
+            let sub_login = connection.subscribe(msg_num)?;
 
             // Login flow is: Send legacy login message, expect back a modern message with Encryption
             // details.  Then, re-send the login as a modern login message.  Expect back a device info
@@ -33,7 +34,7 @@ impl BcCamera {
                 meta: BcMeta {
                     msg_id: MSG_ID_LOGIN,
                     channel_id: self.channel_id,
-                    msg_num: self.new_message_num(),
+                    msg_num,
                     stream_type: 0,
                     response_code: 0xdc02,
                     class: 0x6514,
@@ -85,7 +86,7 @@ impl BcCamera {
                 BcMeta {
                     msg_id: MSG_ID_LOGIN,
                     channel_id: self.channel_id,
-                    msg_num: self.new_message_num(),
+                    msg_num,
                     stream_type: 0,
                     response_code: 0,
                     class: 0x6414,

--- a/crates/core/src/bc_protocol/login.rs
+++ b/crates/core/src/bc_protocol/login.rs
@@ -105,6 +105,9 @@ impl BcCamera {
 
             sub_login.send(modern_login)?;
             let modern_reply = sub_login.rx.recv_timeout(RX_TIMEOUT)?;
+            if modern_reply.meta.response_code != 200 {
+                return Err(Error::CameraServiceUnavaliable);
+            }
 
             match modern_reply.body {
                 BcBody::ModernMsg(ModernMsg {

--- a/crates/core/src/bc_protocol/logout.rs
+++ b/crates/core/src/bc_protocol/logout.rs
@@ -10,7 +10,8 @@ impl BcCamera {
                     .connection
                     .as_ref()
                     .expect("Must be connected to log in");
-                let sub_logout = connection.subscribe(MSG_ID_LOGOUT)?;
+                let msg_num = self.new_message_num();
+                let sub_logout = connection.subscribe(msg_num)?;
 
                 let username = credentials.username.clone();
                 let password = credentials
@@ -23,7 +24,7 @@ impl BcCamera {
                     BcMeta {
                         msg_id: MSG_ID_LOGOUT,
                         channel_id: self.channel_id,
-                        msg_num: self.new_message_num(),
+                        msg_num,
                         stream_type: 0,
                         response_code: 0,
                         class: 0x6414,

--- a/crates/core/src/bc_protocol/ping.rs
+++ b/crates/core/src/bc_protocol/ping.rs
@@ -6,13 +6,14 @@ impl BcCamera {
     /// or error
     pub fn ping(&self) -> Result<()> {
         let connection = self.connection.as_ref().expect("Must be connected to ping");
-        let sub_ping = connection.subscribe(MSG_ID_PING)?;
+        let msg_num = self.new_message_num();
+        let sub_ping = connection.subscribe(msg_num)?;
 
         let ping = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_PING,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 stream_type: 0,
                 response_code: 0,
                 class: 0x6414,

--- a/crates/core/src/bc_protocol/pirstate.rs
+++ b/crates/core/src/bc_protocol/pirstate.rs
@@ -8,12 +8,13 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to get time");
-        let sub_get = connection.subscribe(MSG_ID_GET_PIR_ALARM)?;
+        let msg_num = self.new_message_num();
+        let sub_get = connection.subscribe(msg_num)?;
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_GET_PIR_ALARM,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 response_code: 0,
                 stream_type: 0,
                 class: 0x6414,
@@ -54,13 +55,14 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to get time");
-        let sub_set = connection.subscribe(MSG_ID_START_PIR_ALARM)?;
+        let msg_num = self.new_message_num();
+        let sub_set = connection.subscribe(msg_num)?;
 
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_START_PIR_ALARM,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 response_code: 0,
                 stream_type: 0,
                 class: 0x6414,

--- a/crates/core/src/bc_protocol/pirstate.rs
+++ b/crates/core/src/bc_protocol/pirstate.rs
@@ -30,6 +30,9 @@ impl BcCamera {
 
         sub_get.send(get)?;
         let msg = sub_get.rx.recv_timeout(RX_TIMEOUT)?;
+        if msg.meta.response_code != 200 {
+            return Err(Error::CameraServiceUnavaliable);
+        }
 
         if let BcBody::ModernMsg(ModernMsg {
             payload:
@@ -81,6 +84,9 @@ impl BcCamera {
 
         sub_set.send(get)?;
         let msg = sub_set.rx.recv_timeout(RX_TIMEOUT)?;
+        if msg.meta.response_code != 200 {
+            return Err(Error::CameraServiceUnavaliable);
+        }
 
         if let BcMeta {
             response_code: 200, ..

--- a/crates/core/src/bc_protocol/reboot.rs
+++ b/crates/core/src/bc_protocol/reboot.rs
@@ -5,13 +5,14 @@ impl BcCamera {
     /// Reboot the camera
     pub fn reboot(&self) -> Result<()> {
         let connection = self.connection.as_ref().expect("Must be connected to ping");
-        let sub = connection.subscribe(MSG_ID_REBOOT)?;
+        let msg_num = self.new_message_num();
+        let sub = connection.subscribe(msg_num)?;
 
         let msg = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_REBOOT,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 stream_type: 0,
                 response_code: 0,
                 class: 0x6414,

--- a/crates/core/src/bc_protocol/stream.rs
+++ b/crates/core/src/bc_protocol/stream.rs
@@ -54,7 +54,8 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to start video");
-        let sub_video = connection.subscribe(MSG_ID_VIDEO)?;
+        let msg_num = self.new_message_num();
+        let sub_video = connection.subscribe(msg_num)?;
 
         // On an E1 and swann cameras:
         //  - mainStream always has a value of 0
@@ -96,7 +97,7 @@ impl BcCamera {
             BcMeta {
                 msg_id: MSG_ID_VIDEO,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 stream_type: stream_code,
                 response_code: 0,
                 class: 0x6414, // IDK why

--- a/crates/core/src/bc_protocol/stream.rs
+++ b/crates/core/src/bc_protocol/stream.rs
@@ -123,4 +123,79 @@ impl BcCamera {
             data_outs.write(bc_media)?;
         }
     }
+
+    /// Stop a camera from sending more stream data.
+    pub fn stop_video(&self, stream: Stream) -> Result<()> {
+        let connection = self
+            .connection
+            .as_ref()
+            .expect("Must be connected to stop video");
+        let msg_num = self.new_message_num();
+        let sub_video = connection.subscribe(msg_num)?;
+
+        // On an E1 and swann cameras:
+        //  - mainStream always has a value of 0
+        //  - subStream always has a value of 1
+        //  - There is no externStram
+        // On a B800:
+        //  - mainStream is 0
+        //  - subStream is 0
+        //  - externStream is 0
+        let stream_code = match stream {
+            Stream::Main => 0,
+            Stream::Sub => 1,
+            Stream::Extern => 0,
+        };
+
+        // Theses are the numbers used with the offical client
+        // On an E1 and swann cameras:
+        //  - mainStream always has a value of 0
+        //  - subStream always has a value of 1
+        //  - There is no externStram
+        // On a B800:
+        //  - mainStream is 0
+        //  - subStream is 256
+        //  - externStram is 1024
+        let handle = match stream {
+            Stream::Main => 0,
+            Stream::Sub => 256,
+            Stream::Extern => 1024,
+        };
+
+        let stream_name = match stream {
+            Stream::Main => "mainStream",
+            Stream::Sub => "subStream",
+            Stream::Extern => "externStream",
+        }
+        .to_string();
+
+        let stop_video = Bc::new_from_xml(
+            BcMeta {
+                msg_id: MSG_ID_VIDEO_STOP,
+                channel_id: self.channel_id,
+                msg_num,
+                stream_type: stream_code,
+                response_code: 0,
+                class: 0x6414, // IDK why
+            },
+            BcXml {
+                preview: Some(Preview {
+                    version: xml_ver(),
+                    channel_id: self.channel_id,
+                    handle,
+                    stream_type: stream_name,
+                }),
+                ..Default::default()
+            },
+        );
+
+        sub_video.send(stop_video)?;
+
+        let reply = sub_video.rx.recv_timeout(crate::RX_TIMEOUT)?;
+        if reply.meta.response_code != 200 {
+            return Err(super::Error::CameraServiceUnavaliable);
+        }
+
+        Ok(())
+    }
 }

--- a/crates/core/src/bc_protocol/talk.rs
+++ b/crates/core/src/bc_protocol/talk.rs
@@ -16,13 +16,14 @@ impl BcCamera {
     pub fn talk_stop(&self) -> Result<()> {
         let connection = self.connection.as_ref().expect("Must be connected");
 
-        let sub = connection.subscribe(MSG_ID_TALKRESET)?;
+        let msg_num = self.new_message_num();
+        let sub = connection.subscribe(msg_num)?;
 
         let msg = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_TALKRESET,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 stream_type: 0,
                 response_code: 0,
                 class: 0x6414,
@@ -61,12 +62,13 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to get time");
-        let sub_get = connection.subscribe(MSG_ID_TALKABILITY)?;
+        let msg_num = self.new_message_num();
+        let sub_get = connection.subscribe(msg_num)?;
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_TALKABILITY,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 response_code: 0,
                 stream_type: 0,
                 class: 0x6414,
@@ -120,7 +122,8 @@ impl BcCamera {
     pub fn talk(&self, adpcm: &[u8], talk_config: TalkConfig) -> Result<()> {
         let connection = self.connection.as_ref().expect("Must be connected");
 
-        let sub = connection.subscribe(MSG_ID_TALKCONFIG)?;
+        let msg_num = self.new_message_num();
+        let sub = connection.subscribe(msg_num)?;
 
         if &talk_config.audio_config.audio_type != "adpcm" {
             return Err(Error::UnknownTalkEncoding);
@@ -133,7 +136,7 @@ impl BcCamera {
             meta: BcMeta {
                 msg_id: MSG_ID_TALKCONFIG,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 stream_type: 0,
                 response_code: 0,
                 class: 0x6414,
@@ -181,7 +184,8 @@ impl BcCamera {
         }
 
         let full_block_size = block_size + 4; // Block size + predictor state
-        let sub = connection.subscribe(MSG_ID_TALK)?;
+        let msg_num = self.new_message_num();
+        let sub = connection.subscribe(msg_num)?;
 
         const BLOCK_PER_PAYLOAD: usize = 4;
         const BLOCK_HEADER_SIZE: usize = 4;
@@ -200,7 +204,7 @@ impl BcCamera {
                 meta: BcMeta {
                     msg_id: MSG_ID_TALK,
                     channel_id: self.channel_id,
-                    msg_num: self.new_message_num(),
+                    msg_num,
                     stream_type: 0,
                     response_code: 0,
                     class: 0x6414,
@@ -259,7 +263,8 @@ impl BcCamera {
     pub fn talk_stream(&self, rx: Receiver<Vec<u8>>, talk_config: TalkConfig) -> Result<()> {
         let connection = self.connection.as_ref().expect("Must be connected");
 
-        let sub = connection.subscribe(MSG_ID_TALKCONFIG)?;
+        let msg_num = self.new_message_num();
+        let sub = connection.subscribe(msg_num)?;
 
         if &talk_config.audio_config.audio_type != "adpcm" {
             return Err(Error::UnknownTalkEncoding);
@@ -272,7 +277,7 @@ impl BcCamera {
             meta: BcMeta {
                 msg_id: MSG_ID_TALKCONFIG,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 stream_type: 0,
                 response_code: 0,
                 class: 0x6414,
@@ -320,7 +325,8 @@ impl BcCamera {
         }
 
         let full_block_size = block_size + 4; // Block size + predictor state
-        let sub = connection.subscribe(MSG_ID_TALK)?;
+        let msg_num = self.new_message_num();
+        let sub = connection.subscribe(msg_num)?;
 
         const BLOCK_PER_PAYLOAD: usize = 1;
         const BLOCK_HEADER_SIZE: usize = 4;
@@ -379,7 +385,7 @@ impl BcCamera {
                 meta: BcMeta {
                     msg_id: MSG_ID_TALK,
                     channel_id: self.channel_id,
-                    msg_num: self.new_message_num(),
+                    msg_num,
                     stream_type: 0,
                     response_code: 0,
                     class: 0x6414,

--- a/crates/core/src/bc_protocol/time.rs
+++ b/crates/core/src/bc_protocol/time.rs
@@ -15,12 +15,13 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to get time");
-        let sub_get_general = connection.subscribe(MSG_ID_GET_GENERAL)?;
+        let msg_num = self.new_message_num();
+        let sub_get_general = connection.subscribe(msg_num)?;
         let get = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_GET_GENERAL,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 response_code: 0,
                 stream_type: 0,
                 class: 0x6414,
@@ -98,12 +99,13 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to set time");
-        let sub_set_general = connection.subscribe(MSG_ID_SET_GENERAL)?;
+        let msg_num = self.new_message_num();
+        let sub_set_general = connection.subscribe(msg_num)?;
         let set = Bc::new_from_xml(
             BcMeta {
                 msg_id: MSG_ID_SET_GENERAL,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 response_code: 0,
                 stream_type: 0,
                 class: 0x6414,

--- a/crates/core/src/bc_protocol/time.rs
+++ b/crates/core/src/bc_protocol/time.rs
@@ -31,6 +31,9 @@ impl BcCamera {
 
         sub_get_general.send(get)?;
         let msg = sub_get_general.rx.recv_timeout(RX_TIMEOUT)?;
+        if msg.meta.response_code != 200 {
+            return Err(Error::CameraServiceUnavaliable);
+        }
 
         if let BcBody::ModernMsg(ModernMsg {
             payload:

--- a/crates/core/src/bc_protocol/version.rs
+++ b/crates/core/src/bc_protocol/version.rs
@@ -28,6 +28,9 @@ impl BcCamera {
         sub_version.send(version)?;
 
         let modern_reply = sub_version.rx.recv_timeout(RX_TIMEOUT)?;
+        if modern_reply.meta.response_code != 200 {
+            return Err(Error::CameraServiceUnavaliable);
+        }
         let version_info;
         match modern_reply.body {
             BcBody::ModernMsg(ModernMsg {

--- a/crates/core/src/bc_protocol/version.rs
+++ b/crates/core/src/bc_protocol/version.rs
@@ -8,13 +8,14 @@ impl BcCamera {
             .connection
             .as_ref()
             .expect("Must be connected to get version info");
-        let sub_version = connection.subscribe(MSG_ID_VERSION)?;
+        let msg_num = self.new_message_num();
+        let sub_version = connection.subscribe(msg_num)?;
 
         let version = Bc {
             meta: BcMeta {
                 msg_id: MSG_ID_VERSION,
                 channel_id: self.channel_id,
-                msg_num: self.new_message_num(),
+                msg_num,
                 stream_type: 0,
                 response_code: 0,
                 class: 0x6414, // IDK why

--- a/crates/core/src/bcmedia/de.rs
+++ b/crates/core/src/bcmedia/de.rs
@@ -87,7 +87,7 @@ where
 impl BcMedia {
     pub(crate) fn deserialize<R: Read>(r: R) -> Result<BcMedia, Error> {
         // Throw away the nom-specific return types
-        read_from_reader(|reader| bcmedia(reader), r)
+        read_from_reader(bcmedia, r)
     }
 }
 

--- a/crates/core/src/bcudp/de.rs
+++ b/crates/core/src/bcudp/de.rs
@@ -84,7 +84,7 @@ where
 impl BcUdp {
     pub(crate) fn deserialize<R: Read>(r: R) -> Result<BcUdp, Error> {
         // Throw away the nom-specific return types
-        read_from_reader(|reader| bcudp(reader), r)
+        read_from_reader(bcudp, r)
     }
 }
 

--- a/crates/core/src/bcudp/model.rs
+++ b/crates/core/src/bcudp/model.rs
@@ -5,6 +5,7 @@ use super::xml::*;
 
 /// Top level udp packet
 #[derive(Debug, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum BcUdp {
     /// Packet from the negotiate stage when connection info is exchanged
     Discovery(UdpDiscovery),

--- a/crates/core/src/bcudp/xml_crypto.rs
+++ b/crates/core/src/bcudp/xml_crypto.rs
@@ -5,8 +5,7 @@ const XML_KEY: [u32; 8] = [
 pub(crate) fn decrypt(offset: u32, buf: &[u8]) -> Vec<u8> {
     let key = XML_KEY
         .iter()
-        .map(|i| (i + offset).to_le_bytes())
-        .flatten()
+        .flat_map(|i| (i + offset).to_le_bytes())
         .cycle();
     buf.iter().zip(key).map(|(byte, key)| key ^ byte).collect()
 }

--- a/src/rtsp/gst.rs
+++ b/src/rtsp/gst.rs
@@ -347,7 +347,7 @@ mod maybe_app_src {
         /// owning the AppSrc directly.  This function handles either case and returns the AppSrc,
         /// or None if the caller has not yet sent one.
         fn try_get_src(&mut self) -> Option<&AppSrc> {
-            while let Some(src) = self.rx.try_recv().ok() {
+            while let Ok(src) = self.rx.try_recv() {
                 self.app_src = Some(src);
             }
             self.app_src.as_ref()

--- a/src/rtsp/mod.rs
+++ b/src/rtsp/mod.rs
@@ -214,7 +214,7 @@ fn camera_main(
 ) -> Result<(), CameraErr> {
     let mut connected = false;
     let mut login_fail = false;
-    (|| {
+    (|| -> Result<(), anyhow::Error> {
         let camera_addr =
             AddressOrUid::new(&camera_config.camera_addr, &camera_config.camera_uid).unwrap();
         let mut camera =
@@ -274,13 +274,14 @@ fn camera_main(
                 let camera = arc_camera.clone();
                 let outputs = arc_outputs.clone();
                 let abort_handle = arc_abort_handle.clone();
+                let abort_handle_2 = arc_abort_handle.clone();
 
                 s.spawn(move |_| {
                 let camera_result = camera.start_video(&mut *outputs.lock().unwrap(), *stream_name, abort_handle).with_context(|| format!("Error while streaming {}", camera_config.name));
                 (*camera_results.lock().unwrap()).push(camera_result);
 
                 let _ = camera.stop_video(*stream_name);
-                abort_handle.store(true, Ordering::Relaxed);
+                abort_handle_2.store(true, Ordering::Relaxed);
             });
             }
         }).unwrap();


### PR DESCRIPTION
### Overview
This allows for multiple streams on a single login.

---

### Changes

- Subscriptions are now on message numbers not message IDs
- If the camera sends a response code other than 200 we raise an error
- `camera_main` and `camera_loop` now accept a slice of &[(name, outputs)]
- Arc mutexes used for `outputs` because of threaded mutability
- Added logout message
- Added stop video message
- Made start_camera loop abortable. This is used to stop both HD and SD threads when one of them errors, so that the connection can be reset

### Interesting Model Change

When requesting a camera stream we send the xml

```xml
<?xml version="1.0" encoding="utf-8"?>
<body>
<Preview version="1.1">
<channelId>0</channelId>
<handle>0</handle>
<streamType>mainStream</streamType>
</Preview>
</body>
```

Before we always set handle to `0`.

However if I request two streams with the same handle then the first stream will not send data. In fact the first stream will never send data again until the camera is restarted (instead responding with a 400 code)

So we now request `mainStream`: `handle=0` and `subStream`: `handle=1`

In the header there is already a u8 byte which is 0 for `mainstream` and 1 for `substream` so I presume that this `handle` is the modern version of that byte. Therefore, I have also reduced the size of `handle` to be a u8 which allows us to reuse the byte in the header.