### PR TITLE
Add Arch Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Builds are provided for the following platforms:
 - Debian x86 ([download][debian-x86-ci-download])
 - Debian aarch64 ([download][debian-aarch-ci-download])
 - Debian armhf ([download][debian-armhf-ci-download])
+- Arch Linux ([AUR](https://aur.archlinux.org/packages/neolink-git/))
 - Docker x86 (see below)
 
 ### Windows/Linux


### PR DESCRIPTION
Hello,

Thanks for a great project!
I've been using neolink for a while and decided to publish it to AUR to let other Arch Linux user install neolink using more or less traditional for arch tools.

The PR simply adds a link to the AUR page of the project.