### PR TITLE
Fix IFrame and PFrame identification for Swann DVRs

### DIFF
--- a/crates/core/src/bcmedia/de.rs
+++ b/crates/core/src/bcmedia/de.rs
@@ -76,8 +76,8 @@ fn bcmedia(buf: &[u8]) -> IResult<&[u8], BcMedia> {
             *x,
             MAGIC_HEADER_BCMEDIA_INFO_V1
                 | MAGIC_HEADER_BCMEDIA_INFO_V2
-                | MAGIC_HEADER_BCMEDIA_IFRAME
-                | MAGIC_HEADER_BCMEDIA_PFRAME
+                | MAGIC_HEADER_BCMEDIA_IFRAME..=MAGIC_HEADER_BCMEDIA_IFRAME_LAST
+                | MAGIC_HEADER_BCMEDIA_PFRAME..=MAGIC_HEADER_BCMEDIA_PFRAME_LAST
                 | MAGIC_HEADER_BCMEDIA_AAC
                 | MAGIC_HEADER_BCMEDIA_ADPCM
         )
@@ -92,11 +92,11 @@ fn bcmedia(buf: &[u8]) -> IResult<&[u8], BcMedia> {
             let (buf, payload) = bcmedia_info_v2(buf)?;
             Ok((buf, BcMedia::InfoV2(payload)))
         }
-        MAGIC_HEADER_BCMEDIA_IFRAME => {
+        MAGIC_HEADER_BCMEDIA_IFRAME..=MAGIC_HEADER_BCMEDIA_IFRAME_LAST => {
             let (buf, payload) = bcmedia_iframe(buf)?;
             Ok((buf, BcMedia::Iframe(payload)))
         }
-        MAGIC_HEADER_BCMEDIA_PFRAME => {
+        MAGIC_HEADER_BCMEDIA_PFRAME..=MAGIC_HEADER_BCMEDIA_PFRAME_LAST => {
             let (buf, payload) = bcmedia_pframe(buf)?;
             Ok((buf, BcMedia::Pframe(payload)))
         }

--- a/crates/core/src/bcmedia/model.rs
+++ b/crates/core/src/bcmedia/model.rs
@@ -103,7 +103,9 @@ pub struct BcMediaInfoV2 {
     // unknown: u16
 }
 
+// IFrame magics include the channel number in them
 pub(super) const MAGIC_HEADER_BCMEDIA_IFRAME: u32 = 0x63643030;
+pub(super) const MAGIC_HEADER_BCMEDIA_IFRAME_LAST: u32 = 0x63643039;
 
 /// Video Types for I/PFrame
 #[derive(Debug)]
@@ -132,7 +134,9 @@ pub struct BcMediaIframe {
     pub data: Vec<u8>,
 }
 
+// PFrame magics include the channel number in them
 pub(super) const MAGIC_HEADER_BCMEDIA_PFRAME: u32 = 0x63643130;
+pub(super) const MAGIC_HEADER_BCMEDIA_PFRAME_LAST: u32 = 0x63643139;
 
 /// This is a BcMedia video PFrame.
 #[derive(Debug)]


### PR DESCRIPTION
The Swann DVRs (at least) include the channel number of the streamed channel in (at least) IFrame and PFrame magic numbers. Without this patch, there is a Parsing error leading to a Deserialisation error if a channel ID other than zero is used.

With this patch, neolink works with my Swann DVR-4550 and presumably many other Swann DVRs.