### PR TITLE
Limit UDP keep alive

### DIFF
--- a/crates/core/src/bc_protocol.rs
+++ b/crates/core/src/bc_protocol.rs
@@ -186,23 +186,24 @@ impl BcCamera {
         };
 
         if let Some(conn) = &me.connection {
-            let keep_alive_msg = Bc {
-                meta: BcMeta {
-                    msg_id: MSG_ID_UDP_KEEP_ALIVE,
-                    channel_id: me.channel_id,
-                    msg_num: me.new_message_num(),
-                    stream_type: 0,
-                    response_code: 0,
-                    class: 0x6414,
-                },
-                body: BcBody::ModernMsg(ModernMsg {
-                    ..Default::default()
-                }),
-            };
+            if conn.is_udp() {
+                let keep_alive_msg = Bc {
+                    meta: BcMeta {
+                        msg_id: MSG_ID_UDP_KEEP_ALIVE,
+                        channel_id: me.channel_id,
+                        msg_num: me.new_message_num(),
+                        stream_type: 0,
+                        response_code: 0,
+                        class: 0x6414,
+                    },
+                    body: BcBody::ModernMsg(ModernMsg {
+                        ..Default::default()
+                    }),
+                };
 
-            conn.set_keep_alive_msg(keep_alive_msg);
+                conn.set_keep_alive_msg(keep_alive_msg);
+            }
         }
-
         Ok(me)
     }
 

--- a/crates/core/src/bc_protocol/connection/bcconn.rs
+++ b/crates/core/src/bc_protocol/connection/bcconn.rs
@@ -122,6 +122,10 @@ impl BcConnection {
         (*self.encryption_protocol.lock().unwrap()).clone()
     }
 
+    pub fn is_udp(&self) -> bool {
+        self.sink.lock().unwrap().is_udp()
+    }
+
     fn poll(
         context: &mut BcContext,
         connection: &BcSource,

--- a/crates/core/src/bc_protocol/connection/bcsource.rs
+++ b/crates/core/src/bc_protocol/connection/bcsource.rs
@@ -12,6 +12,10 @@ pub enum BcSource {
 }
 
 impl BcSource {
+    pub fn is_udp(&self) -> bool {
+        matches!(self, BcSource::Udp(_))
+    }
+
     pub fn new_tcp(addr: SocketAddr, timeout: Duration) -> Result<Self> {
         let source = TcpSource::new(addr, timeout)?;
         Ok(BcSource::Tcp(Mutex::new(source)))


### PR DESCRIPTION
I have had a couple of issues related to the UDP keep alive that did not crop up in my initial testing and needs to be fixed.

Some cameras (#231) would not send stream while the UDP keep alive messages were being sent, instead the camera seemed to be overwhelmed by the number of keep alive message and stopped doing anything else except replying to these message with the 400 error code. (This might suggest something about message priority on the cameras)

This PR does the following

1. Limit the keep alive messages to once every 500ms
2. Stop sending keep alive message if the camera replies to them with anything other than a 200 OK response code
3. Only enable keep alive if connection is UDP

fixes #231