### PR TITLE
use new command 'neolink rtsp' in docs

### DIFF
--- a/docs/Setting Up Neolink For Use With Blue Iris.md
+++ b/docs/Setting Up Neolink For Use With Blue Iris.md
@@ -76,7 +76,7 @@ Note: For **E1 Cameras**, refer to [the readme](https://github.com/thirtythreefo
 1. Open a command prompt in the directory that contains Neolink and your config file.
 2. Run the following command (with your correct config file name):
 
-        neolink --config config.toml
+        neolink rtsp --config config.toml
 
 You should get login messages that look something like this:
 
@@ -156,7 +156,7 @@ _The best way to have Neolink run at startup is create a Scheduled Task that sta
 
       `cd C:\Path\to\Neolink\Folder`
 
-      `neolink --config config.toml`
+      `neolink rtsp --config config.toml`
 
    4. Save the file and run it. Make sure Neolink successfully starts.
 

--- a/docs/unix_service.md
+++ b/docs/unix_service.md
@@ -54,7 +54,7 @@ Description=Neolink service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/neolink --config /usr/local/etc/neolink_config.toml
+ExecStart=/usr/local/bin/neolink rtsp --config /usr/local/etc/neolink_config.toml
 Restart=on-failure
 User=neolinker
 Group=neolinker

--- a/docs/unix_setup.md
+++ b/docs/unix_setup.md
@@ -149,7 +149,7 @@ folder where `neolink` and `my_config.toml` are.
 Run neolink with:
 
 ```
-./neolink --config my_config.toml
+./neolink rtsp --config my_config.toml
 ```
 
 You should see messages such as:
@@ -243,7 +243,7 @@ If the mainStream fails but the subStream succeeds you may need to add
   with this command.
 
   ```bash
-  GST_DEBUG=3 ./neolink --config my_config.toml
+  GST_DEBUG=3 ./neolink rtsp --config my_config.toml
   ```
 
   This will print out a lot more information to the terminal. Try to connect
@@ -284,5 +284,5 @@ If the mainStream fails but the subStream succeeds you may need to add
   neolink log. You can save the log to file with the following command:
 
   ```bash
-  GST_DEBUG=3 ./neolink --config my_config.toml 2>&1 > neolink.log
+  GST_DEBUG=3 ./neolink rtsp --config my_config.toml 2>&1 > neolink.log
   ```


### PR DESCRIPTION
on some places in the docs the old command 'neolink ...' was used.
that raises a warning, so refer to 'neolink rtsp' where apropriate
