### PR TITLE
Fix typo in help for talk command

### DIFF
--- a/src/talk/cmdline.rs
+++ b/src/talk/cmdline.rs
@@ -9,13 +9,13 @@ use structopt::StructOpt;
 /// `gst-launch` can be used to prepare this data
 #[derive(StructOpt, Debug)]
 pub struct Opt {
-    /// The name of the camera to change the lights of. Must be a name in the config
+    /// The name of the camera to talk through. Must be a name in the config
     pub camera: String,
     /// The path to the audio file.
     #[structopt(short, long, parse(from_os_str), conflicts_with = "microphone")]
     pub file_path: Option<PathBuf>,
     /// Use the microphone as the source. Defaults to autoaudiosrc - Which microphone depends
-    /// on [gstraemer](https://gstreamer.freedesktop.org/documentation/autodetect/autoaudiosrc.html?gi-language=c#autoaudiosrc-page)
+    /// on [gstreamer](https://gstreamer.freedesktop.org/documentation/autodetect/autoaudiosrc.html?gi-language=c#autoaudiosrc-page)
     #[structopt(short, long, conflicts_with = "file_path")]
     pub microphone: bool,
     /// Use a specific microphone like "alsasrc device=hw:1"


### PR DESCRIPTION
Thanks for this project - got my Reolink that I picked up on a whim at the thrift store up and running like a charm!

Noticed a couple typos when digging around the help, so I figured I'd fix 'em - I assume these triple-slash comments are somehow generated into documentation (which is super rad, taking notes for my next Rust project!)