### PR TITLE
Add PTZ control via direct movement and presets

### DIFF
--- a/crates/core/src/bc/model.rs
+++ b/crates/core/src/bc/model.rs
@@ -14,6 +14,10 @@ pub const MSG_ID_VIDEO: u32 = 3;
 pub const MSG_ID_TALKABILITY: u32 = 10;
 /// TalkReset messages have this ID
 pub const MSG_ID_TALKRESET: u32 = 11;
+/// PTZ motion control
+pub const MSG_ID_PTZ_CONTROL: u32 = 18;
+/// PTZ goto preset position
+pub const MSG_ID_PTZ_CONTROL_PRESET: u32 = 19;
 /// Reboot messages have this ID
 pub const MSG_ID_REBOOT: u32 = 23;
 /// Request motion detection messages
@@ -32,6 +36,8 @@ pub const MSG_ID_PING: u32 = 93;
 pub const MSG_ID_GET_GENERAL: u32 = 104;
 /// Setting general system info (clock mostly) messages have this ID
 pub const MSG_ID_SET_GENERAL: u32 = 105;
+/// Get the available PTZ position presets
+pub const MSG_ID_GET_PTZ_PRESET: u32 = 190;
 /// Will send the talk config for talk back data to follow this msg
 pub const MSG_ID_TALKCONFIG: u32 = 201;
 /// Used to send talk back binary data

--- a/crates/core/src/bc/xml.rs
+++ b/crates/core/src/bc/xml.rs
@@ -72,6 +72,12 @@ pub struct BcXml {
     /// Received when motion is detected
     #[yaserde(rename = "AlarmEventList")]
     pub alarm_event_list: Option<AlarmEventList>,
+    /// Sent or received for the PTZ preset functionality
+    #[yaserde(rename = "PtzPreset")]
+    pub ptz_preset: Option<PtzPreset>,
+    /// Sent when performing PTZ movement
+    #[yaserde(rename = "PtzControl")]
+    pub ptz_control: Option<PtzControl>,
 }
 
 impl BcXml {
@@ -424,6 +430,54 @@ pub struct AlarmEventList {
     /// List of events
     #[yaserde(rename = "AlarmEvent")]
     pub alarm_events: Vec<AlarmEvent>,
+}
+
+/// An XML that describes a list of available PTZ presets
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct PtzPreset {
+    /// XML Version
+    #[yaserde(attribute)]
+    pub version: String,
+    /// The channel ID. Usually zero unless from an NVR
+    #[yaserde(rename = "channelId")]
+    pub channel_id: u8,
+    /// List of presets
+    #[yaserde(rename = "presetList")]
+    pub preset_list: Option<PresetList>
+}
+
+/// A preset list
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct PresetList {
+    /// List of Presets
+    pub preset: Vec<Preset>
+}
+
+/// A preset. Either contains the ID and the name or the ID and the command
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct Preset {
+    /// The ID of the preset
+    pub id: i8,
+    /// The preset name
+    pub name: Option<String>,
+    /// Command: Known values: `"toPos"` and `"setPos"`
+    pub command: Option<String>
+}
+
+/// A PTZ control message containing speed and direction of the movement
+#[derive(PartialEq, Eq, Default, Debug, YaDeserialize, YaSerialize)]
+pub struct PtzControl {
+    /// XML Version
+    #[yaserde(attribute)]
+    pub version: String,
+    /// The channel the event occurred on. Usually zero unless from an NVR
+    #[yaserde(rename = "channelId")]
+    pub channel_id: u8,
+    /// Motion speed. Only known values are `0` (stop command) and `32`
+    pub speed: i8,
+    /// Motion command. Known values are `"left"`, `"right"`, `"up"`, `"down"`, `"leftUp"`,
+    /// `"leftDown"`, `"rightUp"`, `"rightDown"` and `"stop"`
+    pub command: String
 }
 
 /// An alarm event. Camera can send multiple per message as an array in AlarmEventList.

--- a/crates/core/src/bc_protocol.rs
+++ b/crates/core/src/bc_protocol.rs
@@ -14,6 +14,7 @@ mod logout;
 mod motion;
 mod ping;
 mod pirstate;
+mod ptz;
 mod reboot;
 mod resolution;
 mod stream;

--- a/crates/core/src/bc_protocol/ptz.rs
+++ b/crates/core/src/bc_protocol/ptz.rs
@@ -1,0 +1,163 @@
+use super::{BcCamera, Error, Result, RX_TIMEOUT};
+use crate::bc::{model::*, xml::*};
+
+impl BcCamera {
+    /// Get the [PtzPreset] XML which contains the list of the preset positions known to the camera
+    pub fn get_ptz_preset(&self) -> Result<PtzPreset> {
+        let connection = self
+            .connection
+            .as_ref()
+            .expect("Must be connected to get time");
+        let sub_set = connection.subscribe(MSG_ID_GET_PTZ_PRESET)?;
+
+        let get = Bc {
+            meta: BcMeta {
+                msg_id: MSG_ID_GET_PTZ_PRESET,
+                channel_id: self.channel_id,
+                msg_num: self.new_message_num(),
+                response_code: 0,
+                stream_type: 0,
+                class: 0x6414,
+            },
+            body: BcBody::ModernMsg(ModernMsg {
+                extension: Some(Extension {
+                    channel_id: Some(self.channel_id),
+                    ..Default::default()
+                }),
+                payload: None
+            }),
+        };
+        sub_set.send(get)?;
+
+        let msg = sub_set.rx.recv_timeout(RX_TIMEOUT)?;
+
+        if let BcBody::ModernMsg(ModernMsg {
+             payload: Some(BcPayloads::BcXml(BcXml {
+                 ptz_preset: Some(ptz_preset),
+                 ..
+             })),
+             ..
+        }) = msg.body {
+            Ok(ptz_preset)
+        } else {
+            Err(Error::UnintelligibleReply {
+                reply: msg,
+                why: "The camera did not return a valid PtzPreset xml",
+            })
+        }
+    }
+
+    /// Set a PTZ preset. If a [name] is given the current position will be saved as a preset
+    /// with the given [preset_id] and [name], otherwise the camera will attempt to move to the
+    /// preset with the given ID.
+    pub fn set_ptz_preset(&self, preset_id: i8, name: Option<String>) -> Result<()> {
+        let connection = self
+            .connection
+            .as_ref()
+            .expect("Must be connected to get time");
+        let sub_set = connection.subscribe(MSG_ID_PTZ_CONTROL_PRESET)?;
+        let command = if name.is_some() {
+            "setPos"
+        } else {
+            "toPos"
+        };
+        let preset = Preset {
+            id: preset_id,
+            name,
+            command: Some(command.to_string()),
+            ..Default::default()
+        };
+        let get = Bc {
+            meta: BcMeta {
+                msg_id: MSG_ID_PTZ_CONTROL_PRESET,
+                channel_id: self.channel_id,
+                msg_num: self.new_message_num(),
+                response_code: 0,
+                stream_type: 0,
+                class: 0x6414,
+            },
+
+
+            body: BcBody::ModernMsg(ModernMsg {
+                extension: Some(Extension {
+                    channel_id: Some(self.channel_id),
+                    ..Default::default()
+                }),
+                payload: Some(BcPayloads::BcXml(BcXml {
+                    ptz_preset: Some(PtzPreset {
+                        preset_list: Some(PresetList {
+                            preset: vec![preset],
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })),
+            }),
+        };
+        sub_set.send(get)?;
+        let msg = sub_set.rx.recv_timeout(RX_TIMEOUT)?;
+
+        if let BcMeta {
+            response_code: 200, ..
+        } = msg.meta
+        {
+            Ok(())
+        } else {
+            Err(Error::UnintelligibleReply {
+                reply: msg,
+                why: "The camera did not accept the PtzPreset xml",
+            })
+        }
+    }
+
+    /// Move the camera with given speed and command. The only known value for speed is 32.
+    /// [command] might be `left`, `right`, `up`, `down`, `leftUp`, `leftDown`, `rightUp`,
+    /// `rightDown` or `stop`
+    pub fn ptz_control(&self, speed: i8, command: String) -> Result<()> {
+        let connection = self
+            .connection
+            .as_ref()
+            .expect("Must be connected to get time");
+        let sub_set = connection.subscribe(MSG_ID_PTZ_CONTROL)?;
+
+        let get = Bc {
+            meta: BcMeta {
+                msg_id: MSG_ID_PTZ_CONTROL,
+                channel_id: self.channel_id,
+                msg_num: self.new_message_num(),
+                response_code: 0,
+                stream_type: 0,
+                class: 0x6414,
+            },
+
+            body: BcBody::ModernMsg(ModernMsg {
+                extension: Some(Extension {
+                    channel_id: Some(self.channel_id),
+                    ..Default::default()
+                }),
+                payload: Some(BcPayloads::BcXml(BcXml {
+                    ptz_control: Some(PtzControl {
+                        speed,
+                        command,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })),
+            }),
+        };
+        sub_set.send(get)?;
+        let msg = sub_set.rx.recv_timeout(RX_TIMEOUT)?;
+
+        if let BcMeta {
+            response_code: 200, ..
+        } = msg.meta
+        {
+            Ok(())
+        } else {
+            Err(Error::UnintelligibleReply {
+                reply: msg,
+                why: "The camera did not accept the PTZ command",
+            })
+        }
+    }
+}

--- a/dissector/baichuan.lua
+++ b/dissector/baichuan.lua
@@ -88,6 +88,7 @@ local message_types = {
   [15]="<FileInfoList>",
   [16]="<FileInfoList>",
   [18]="<PtzControl>",
+  [19]="<PtzPreset>",
   [23]="Reboot",
   [25]="<VideoInput> (write)",
   [26]="<VideoInput>", -- <InputAdvanceCfg>

--- a/dissector/messages.md
+++ b/dissector/messages.md
@@ -354,6 +354,10 @@ Message have zero to two payloads.
     </PtzControl>
     </body>
     ```
+    
+    - **Notes** : The only known values for speed are `32` for any movement and `0` for stop. The known movement
+                  commands are `"left"`, `"right"`, `"up"`, `"down"`, `"leftUp"`, `"leftDown"`, `"rightUp"`, 
+                  `"rightDown"` and `"stop"` although the diagonal movement does not seem to work.
 
   - Camera
 
@@ -362,6 +366,45 @@ Message have zero to two payloads.
         |    Magic     |  Message ID  | Message Length | Encryption Offset |    Status Code    | Message Class | Payload Offset |
         |--------------|--------------|----------------|-------------------|-------------------|---------------|---------------|
         | 0a bc de f0  | 00 00 00 12  |  00 00 00 00   |    1e 00 00 00    |       c8 00       |     00 00     |  00 00 00 00  |
+
+- 19: `<PtzPreset>`
+
+  - Client
+
+    - Header
+
+        |    Magic     | Message ID  | Message Length | Encryption Offset |    Status Code    | Message Class | Payload Offset |
+        |--------------|-------------|----------------|-------------------|-------------------|---------------|---------------|
+        | 0a bc de f0  | 00 00 00 13 | 00 00 01 44    |    1e 00 00 00    |       00 00       |     64 14     |  00 00 00 00  |
+
+    - Payload
+
+    ```xml
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <body>
+    <PtzPreset version="1.1">
+    <channelId>0</channelId>
+    <presetList>
+    <preset>
+    <id>0</id>
+    <command>setPos</command>
+    <name>Test</name>
+    </preset>
+    </presetList>
+    </PtzPreset>
+    </body>
+    ```
+    
+    - **Notes** : The known values for command are `"setPos"` and `"toPos"`
+
+  - Camera
+
+    - Header
+
+        |    Magic     | Message ID  | Message Length | Encryption Offset |    Status Code    | Message Class | Payload Offset |
+        |--------------|-------------|----------------|-------------------|-------------------|---------------|---------------|
+        | 0a bc de f0  | 00 00 00 13 |  00 00 00 00   |    1e 00 00 00    |       c8 00       |     00 00     |  00 00 00 00  |
+
 
 - 23: `Reboot`
 
@@ -1987,7 +2030,12 @@ Message have zero to two payloads.
     <body>
     <PtzPreset version="1.1">
     <channelId>0</channelId>
-    <presetList />
+    <presetList>
+    <preset>
+    <id>0</id>
+    <name>Test</name>
+    </preset>
+    </presetList>
     </PtzPreset>
     </body>
     ```

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -24,5 +24,6 @@ pub enum Command {
     StatusLight(super::statusled::Opt),
     Reboot(super::reboot::Opt),
     Pir(super::pir::Opt),
+    Ptz(super::ptz::Opt),
     Talk(super::talk::Opt),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use validator::Validate;
 mod cmdline;
 mod config;
 mod pir;
+mod ptz;
 mod reboot;
 mod rtsp;
 mod statusled;
@@ -80,6 +81,9 @@ fn main() -> Result<()> {
         }
         Some(Command::Pir(opts)) => {
             pir::main(opts, config)?;
+        }
+        Some(Command::Ptz(opts)) => {
+            ptz::main(opts, config)?;
         }
         Some(Command::Talk(opts)) => {
             talk::main(opts, config)?;

--- a/src/ptz/cmdline.rs
+++ b/src/ptz/cmdline.rs
@@ -1,0 +1,30 @@
+use structopt::StructOpt;
+
+/// The ptz command will control the positioning of the camera
+#[derive(StructOpt, Debug)]
+pub struct Opt {
+    /// The name of the camera to change the lights of. Must be a name in the config
+    pub camera: String,
+
+    #[structopt(subcommand)]
+    pub cmd: PtzCommand,
+}
+
+#[derive(StructOpt, Debug)]
+pub enum PtzCommand {
+    /// Gets the available presets on the camera, moves the camera to a given preset ID or saves
+    /// the current position as a preset with name and ID.
+    Preset {
+        preset_id: Option<i8>,
+        name: Option<String>
+    },
+    /// Performs a movement in the given direction
+    Control {
+        /// The time in milliseconds to move
+        duration: u32,
+        /// The direction command
+        #[structopt(possible_values(&["left", "right", "up", "down"]))]
+        command: String
+    }
+}
+

--- a/src/ptz/mod.rs
+++ b/src/ptz/mod.rs
@@ -1,0 +1,63 @@
+///
+/// # Neolink PTZ Control
+///
+/// This module handles the controls of the PTZ commands
+///
+/// # Usage
+///
+/// ```bash
+/// # Rotate left for 300 milliseconds
+/// neolink status-light --config=config.toml CameraName control 300 left
+/// # Print the list of preset positions
+/// neolink status-light --config=config.toml CameraName preset
+/// # Move the camera to preset ID 0
+/// neolink status-light --config=config.toml CameraName preset 0
+/// # Save the current position as preset ID 0 with name PresetName
+/// neolink status-light --config=config.toml CameraName preset 0 PresetName
+/// ```
+///
+use anyhow::{Context, Result};
+use std::thread::sleep;
+use std::time::Duration;
+
+mod cmdline;
+
+use super::config::Config;
+use crate::utils::find_and_connect;
+use crate::ptz::cmdline::PtzCommand;
+pub(crate) use cmdline::Opt;
+
+/// Entry point for the ptz subcommand
+///
+/// Opt is the command line options
+pub(crate) fn main(opt: Opt, config: Config) -> Result<()> {
+    let camera = find_and_connect(&config, &opt.camera)?;
+
+    match opt.cmd {
+        PtzCommand::Preset {preset_id, name} => {
+            if preset_id.is_some() {
+                camera
+                    .set_ptz_preset(preset_id.unwrap(), name)
+                    .context("Unable to set PTZ preset")?;
+            } else {
+                let preset_list = camera
+                    .get_ptz_preset()
+                    .context("Unable to get PTZ presets")?;
+                println!("Available presets:\nID Name");
+                for preset in preset_list.preset_list.unwrap().preset {
+                    println!("{:<2} {}", preset.id, preset.name.unwrap());
+                }
+            }
+        },
+        PtzCommand::Control {duration, command} => {
+            camera
+                .ptz_control(32, command)
+                .context("Unable to execute PTZ move command")?;
+            sleep(Duration::from_millis(duration as u64));
+            camera
+                .ptz_control(0, "stop".parse()?)
+                .context("Unable to execute PTZ move command")?;
+        }
+    };
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the ability to control the cameras PTZ movement.

The new command line functions can either perform movement for a given time in a given direction or read out, set and move to the cameras position presets.

As I only have a Reolink E1 for development and the camera does not feature a zoom function there are no commands/options to zoom yet.